### PR TITLE
Remove argument for poetry install in quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -361,7 +361,7 @@ by installing the code using |Poetry|.
 
     # If you don't have Poetry installed, you can install it with:
     # pip install poetry
-    poetry install .
+    poetry install
 
 This will install |astrodata| in editable mode, along with all of the
 development dependencies. You can now run tests, build documentation,


### PR DESCRIPTION
In a recent version of poetry (1.8.3) no positional arguments are allowed in `poetry install`.

```bash
$ poetry install .                                                            

No arguments expected for "install" command, got "."
```