### PR TITLE
Developer install consolidation in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,13 @@ test.fits
 
 # scratch directory
 .scratch/
+
+# Loggging files
+*.log
+*.logs
+
+# Coverage json
+*coverage.json
+
+# Meta yaml file
+astrodata/meta.yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [DRAGONS link]: https://github.com/GeminiDRSoftware/DRAGONS
 [astrodata docs]: https://geminidrsoftware.github.io/astrodata/
-[astrodata repo]: https://geminidrsoftware.github.io/astrodata/
+[astrodata repo]: https://github.com/GeminiDRSoftware/astrodata/
 [astropy link]: https://astropy.org
 [pypi link]: https://pypi.org/project/astrodata
 
@@ -167,39 +167,16 @@ Installing development dependencies
 -----------------------------------
 
 ``astrodata`` uses [Poetry](https://github.com/python-poetry/poetry) for build
-and package management. To install development dependencies, you must clone
-this repository. Once you have, at the top level directory of the `astrodata`
-repository run
-
-```
-pip install --upgrade pip
-pip install poetry
-poetry install
-```
-
-To install without specific development groups, omit those you would prefer
-not be installed
-```
-poetry install --without test,docs,dev
-```
-
-
-Or, you can specify specific groups to be installed. E.g., to install the
-main and development dependencies:
-```
-poetry install --only main,dev
-```
-
-The command installs the requested dependencies as well as the current
-project in "editable" mode (equivalent to `pip install -e .`).
-
+and package management. Our documentation includes an [installation guide for
+`astrodata`
+developers](https://geminidrsoftware.github.io/astrodata/developer/index.html)
 
 Contributing
 ------------
 
 See [our contributing guidelines](CONTRIBUTING.md) for information on
 contributing. If you're worried about contributing, or feel intimidated, please
-remember that your contribution is immensly appreciated---no matter how small!
+remember that your contribution is immensely appreciated---no matter how small!
 
 License
 -------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,6 +160,9 @@ rst_prolog = """
 .. |ProgManual| replace:: |DeveloperGuide|
 .. |ProgrammerManual| replace:: |DeveloperGuide|
 .. |Examples| replace:: :doc:`Examples </examples/index>`
+.. |QuickStart| replace:: :doc:`Quick Start </quickstart>`
+.. |DeveloperInstall| replace:: :doc:`Developer Installation </developer/index>`
+
 
 
 .. _`Anaconda`: https://www.anaconda.com/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,7 +206,8 @@ rst_prolog = """
 .. |Tag| replace:: :class:`~astrodata.Tag`
 .. |Descriptors| replace:: :ref:`ad_descriptors`
 
-.. |IssueTracker| replace:: `Issue Tracker <https://github.com/teald/astrodata/issues>`__
+.. |IssueTracker| replace:: `Issue Tracker <https://github.com/GeminiDRSoftware/astrodata/issues>`__
+.. |astrodata_github| replace:: `astrodata GitHub <https://github.com/GeminiDRSoftware/astrodata>`__
 
 .. TODO: below are broken links
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -185,3 +185,8 @@ enter a developer shell.
    python -m venv .venv
    source .venv/bin/activate
    poetry install
+
+..
+   If there is anything else needed for this document, please
+   split this up into separate documents. It's at its visual limit here
+   (otherwise there's too much text for this to be a quick read).

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -1,3 +1,4 @@
+======================
 Developer Installation
 ======================
 
@@ -27,10 +28,16 @@ To install |astrodata|, you will need the following:
 - Python 3.10, 3.11, or 3.12
 - Poetry_ in some flavor
 
-Please see the Poetry_ documentation for installation instructions.
+Please see the Poetry_ documentation for installation instructions. Note that
+it is *not recommended to install Poetry with pip, especially in your working
+directory for the project*.  There are several solutions to this in their
+documentation.
+
+Instructions
+------------
 
 Clone the repository
---------------------
+====================
 
 First, clone the repository from GitHub. Using the command line:
 
@@ -41,7 +48,7 @@ First, clone the repository from GitHub. Using the command line:
 Or use your preferred method for cloning a repository.
 
 Install the dependencies
-------------------------
+========================
 
 ``cd`` into the repository directory:
 
@@ -115,3 +122,66 @@ And then run the tests for a specific environment by running:
     This will be soon replaced by ``nox``, which has continuing support for
     testing with ``conda`` environments. However, the setup/execution is
     similarly simple.
+
+Other development commands
+--------------------------
+
+
+Development with a Poetry environment
+=====================================
+
+|Poetry| also has a feature to create a shell with the dependencies installed.
+This is useful for development, as it allows you to run commands in the
+environment without activating it. To create a shell, run:
+
+.. code-block:: bash
+
+   poetry shell
+
+This will create a shell with the dependencies installed. You can then run
+commands in this shell as you would in a normal shell. To exit the shell, run:
+
+.. code-block:: bash
+
+   exit
+
+This takes similar steps to the above, but make Poetry handle the environment
+for you. While this is convenient, it can be confusing if you're not familiar
+with virtual environments and the shell command itself is somewhat limited in
+what it can do. It will work quickly, though, and can be useful for quick
+development tasks requiring a fresh environment.
+
+Refer to the `Poetry documentation
+<https://python-poetry.org/docs/cli/#shell>`__ for more information on the
+``shell`` command.
+
+Development without a Virtual Environment
+=========================================
+
+If you don't need a virtual environment, you can use the ``poetry run`` command
+to run commands in the environment without activating it. For example, to run
+the tests without activating the environment, you can run:
+
+.. code-block:: bash
+
+   poetry run tox
+
+This will run the tests in an environment created by poetry without activating
+the environment within your shell. This is especially useful for our CI/CD
+tasks, and can be useful for running in an environment that is not your
+development environment.
+
+Copy/Paste to create and enter a developer environment
+------------------------------------------------------
+
+This is for convenience to copy/paste the above commands required to create and
+enter a developer shell.
+
+.. code-block:: bash
+
+   # Start in the directory you'd like to keep astrodata in.
+   git clone git@github.com:GeminiDRSoftware/astrodata.git
+   cd astrodata
+   python -m venv .venv
+   source .venv/bin/activate
+   poetry install

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -27,7 +27,7 @@ To install |astrodata|, you will need the following:
 - Python 3.10, 3.11, or 3.12
 - Poetry_ in some flavor
 
-Please see the |poetry| documentation for installation instructions.
+Please see the Poetry_ documentation for installation instructions.
 
 Clone the repository
 --------------------

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -1,0 +1,117 @@
+Developer Installation
+======================
+
+This guide will walk you through setting up a development environment for
+|astrodata|. If you are a user looking to install |astrodata| for personal use,
+and are just looking to install the package as a dependency, see the
+|Quickstart|.
+
+.. note::
+    This guide assumes you are familiar with the basics of Python development,
+    including virtual environments, package management, and testing. It focuses
+    on setting up your development environment, not why or how these things
+    work.
+
+.. warning::
+    This guide only applies to development on UNIX-like systems, like linux
+    distributions and macOS. If you're developing on Windows, you may need to
+    adapt some of the commands and instructions to work with your system.
+
+Requirements
+------------
+
+.. _Poetry: https://python-poetry.org/docs/
+
+To install |astrodata|, you will need the following:
+
+- Python 3.10, 3.11, or 3.12
+- Poetry_ in some flavor
+
+Please see the |poetry| documentation for installation instructions.
+
+Clone the repository
+--------------------
+
+First, clone the repository from GitHub. Using the command line:
+
+.. code-block:: bash
+
+   git clone git@github.com:GeminiDRSoftware/astrodata.git
+
+Or use your preferred method for cloning a repository.
+
+Install the dependencies
+------------------------
+
+``cd`` into the repository directory:
+
+.. code-block:: bash
+
+   cd astrodata
+
+If you are not already inside a virtual environment of some flavor, such as a
+``conda`` or ``venv`` environment, create one now. For example, to create a new
+virtual environment with ``venv``:
+
+.. code-block:: bash
+
+   python -m venv .venv
+   source .venv/bin/activate
+
+To install the dependencies, navigate to the root of the repository and run:
+
+.. code-block:: bash
+
+   poetry install
+
+
+This will install all the dependencies needed to run |astrodata| within your
+virtual environment, including all test, development, and documentation
+dependencies. This installs |astrodata| in a way that's equivalent to
+installing with
+`pip in editable mode <https://setuptools.pypa.io/en/latest/userguide/development_mode.html>`.
+
+.. note::
+    You can install specific dependency groups by running ``poetry install
+    --only``. For example, to install the ``main`` and ``test`` dependencies:
+
+    .. code-block:: bash
+
+       poetry install --only main,test
+
+    The groups must be separated by commas, and the groups are defined in the
+    ``pyproject.toml`` file.
+
+    Unless you are working on the documentation or testing specifically, you
+    will likely never need to isolate dependencies in this way. This is
+    primarily used for optimizing CI/CD workflows.
+
+Run the tests
+-------------
+
+.. _tox: https://tox.readthedocs.io/
+
+|astrodata| uses tox_ for running tests. To run the tests, simply run:
+
+.. code-block:: bash
+
+   tox
+
+If you would like to run a specific test, or using a specific version or
+python, you can view the available test environments by running:
+
+.. code-block:: bash
+
+   tox -l
+
+And then run the tests for a specific environment by running:
+
+.. code-block:: bash
+
+   tox -e <environment>
+   # e.g., tox -e py310 to run tests with Python 3.10.
+
+.. warning::
+    This will be soon replaced by ``nox``, which has continuing support for
+    testing with ``conda`` environments. However, the setup/execution is
+    similarly simple.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ This is the documentation for astrodata.
    quickstart.rst
    manuals/index
    examples/index
+   developer/index
    api_short
 
 

--- a/docs/manuals/index.rst
+++ b/docs/manuals/index.rst
@@ -23,7 +23,7 @@ Astrodata Manual
 This documentation provides different levels of information:
 
 - :doc:`cheatsheet` - A refresher on common astrodata operations
-- :doc:`usermanual/index` - How to code with astrodata
+- :doc:`usermanual/index` - How to code with astrodata objects
 - :doc:`progmanual/index` - How to code for astrodata
 - :doc:`full_api` - The full API documentation for developers.
 - :doc:`../examples/index` - Examples of how to use astrodata

--- a/docs/manuals/progmanual/intro.rst
+++ b/docs/manuals/progmanual/intro.rst
@@ -6,6 +6,13 @@
 Introduction
 ************
 
+
+.. note::
+    This guide discusses programming your own data interfaces using
+    |astrodata|. If you instead plan to develop the |astrodata| package
+    itself, please see |DeveloperInstall| before starting this guide to install
+    developer dependencies.
+
 AstroData is a Python package that provides a common interface to astronomical
 data. Originally part of the |DRAGONS| package, the data reduction package
 developed at the Gemini Observatory, it has been split into its own package to

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -345,43 +345,5 @@ features available. For examples of usage in practice, check out |DRAGONS|'s
 
 If you plan on developing |astrodata|, or you'd like to use the same
 development environment |astrodata| uses, you can install |astrodata|
-with development dependencies.
-
-Installing |astrodata| with developer dependencies
-++++++++++++++++++++++++++++++++++++++++++++++++++
-
-|astrodata| relies on a number of packages for development, testing, and
-documentation. If you want to install these dependencies, you can do so
-by installing the code using |Poetry|.
-
-.. code-block:: bash
-
-    git clone https://github.com/GeminiDRSoftware/astrodata
-    cd astrodata
-
-    # If you don't have Poetry installed, you can install it with:
-    # pip install poetry
-    poetry install
-
-This will install |astrodata| in editable mode, along with all of the
-development dependencies. You can now run tests, build documentation,
-and run your code using a complete development environment genreated
-by |Poetry|:
-
-.. code-block:: bash
-
-    # Run the tests
-    # Note: tests are performed on all supported python versions, and if you
-    # don't have a specific version installed, that test run will be skipped.
-    poetry run tox -rp
-
-    # Build the documentation from source.
-    poetry run sphinx-build docs docs/_build
-
-    # Run your code
-    poetry run python my_script.py
-
-You may, of course, install these dependencies into a local environment, if you
-prefer. For more information about ``Poetry`` and developing with it, see the
-`Poetry basic usage documentation
-<https://python-poetry.org/docs/basic-usage/#using-your-virtual-environment>`.
+with development dependencies. See the |DeveloperInstall| guide for more
+information.


### PR DESCRIPTION
As discussed in issues #23 and #25, the development installation instructions are in multiple places and inconsistent. This has been partially resolved in #21, but this PR addresses the ambiguities and adds a new Developer Installation page that walks through the process.

## Related Issues
Closes:
+ #23 
+ #25