### PR TITLE
Add linting workflow on push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+# Linting workflow for github actions that runs the pre-commit hooks on all
+# files in the repository.
+name: Lint
+
+# Run this workflow on every push to the repository and on manual trigger.
+on:
+    push:
+    workflow_dispatch:
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v4
+
+            - name: Run image
+              uses: abatilo/actions-poetry@v2
+
+            - name: Install linting (dev) dependencies
+              run: poetry install --only=dev
+
+            - name: Run pre-commit hooks
+              run: poetry run pre-commit run --all-files


### PR DESCRIPTION
This PR adds a new action that will execute on every push to ensure that `pre-commit` hooks (used for linting & various styling/maintenance things) will run on each commit at least once---even when someone does not have `pre-commit` installed.

This PR will close issue #30.