### PR TITLE
Fix pre-commit default 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_stages: ["pre-commit"]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0


### PR DESCRIPTION
Previously, pre-commit hooks would run twice with `commit-msg` stage specific (for checking the commit messages). This is no longer the case. All hooks without a specific stage to run in will only run in the `pre-commit` stage instead of all stages they are available for.