### PR TITLE
[FIX] Have publishing workflow test before publishing

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -8,6 +8,7 @@ on:
     schedule:
         - cron: "20 1 * * mon"
     workflow_dispatch:
+    workflow_call:
 
 defaults:
     run:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -2,9 +2,9 @@ name: PyPI package
 
 on:
   push:
-    tags:
-      # Matches any tags; tags are only used for versioning in this project.
-      - '*'
+    # tags:
+    #   # Matches any tags; tags are only used for versioning in this project.
+    #   - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -2,9 +2,9 @@ name: PyPI package
 
 on:
   push:
-    # tags:
-    #   # Matches any tags; tags are only used for versioning in this project.
-    #   - '*'
+    tags:
+      # Matches any tags; tags are only used for versioning in this project.
+      - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -47,6 +47,7 @@ jobs:
           poetry build
 
       - name: Mint token
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: mint
         uses: tschm/token-mint-action@v1.0.3
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -56,4 +56,4 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
            echo "PUBLISHING!!!! ✨🚀"
-        #  poetry publish -u __token__ -p '${{ steps.mint.outputs.api-token }}'
+           poetry publish -u __token__ -p '${{ steps.mint.outputs.api-token }}'

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,9 +5,20 @@ on:
     tags:
       # Matches any tags; tags are only used for versioning in this project.
       - '*'
+  workflow_dispatch:
 
 jobs:
+  source_test:
+    # This runs the test files on the repository before publishing it.
+    name: Source tests
+    uses: ./.github/workflows/source_tests.yml
+
+  build_test:
+    name: Build tests
+    uses: ./.github/workflows/build_tests.yml
+
   deploy:
+    needs: [source_test, build_test]
     runs-on: ubuntu-latest
 
     permissions:
@@ -39,5 +50,9 @@ jobs:
         uses: tschm/token-mint-action@v1.0.3
 
       - name: Publish the package with poetry
+        # Allow workflow dispatch to trigger this job, but don't allow it
+        # to publish the package to PyPI.
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          poetry publish -u __token__ -p '${{ steps.mint.outputs.api-token }}'
+           echo "PUBLISHING!!!! ✨🚀"
+        #  poetry publish -u __token__ -p '${{ steps.mint.outputs.api-token }}'

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -40,6 +40,7 @@ jobs:
           virtualenvs-create: false
 
       - name: Update version (kept at 0.0.0) in pyproject.toml and build
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           poetry version ${{ github.ref_name }}
           poetry version
@@ -52,7 +53,7 @@ jobs:
       - name: Publish the package with poetry
         # Allow workflow dispatch to trigger this job, but don't allow it
         # to publish the package to PyPI.
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
            echo "PUBLISHING!!!! ✨🚀"
         #  poetry publish -u __token__ -p '${{ steps.mint.outputs.api-token }}'

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -8,6 +8,7 @@ on:
     schedule:
         - cron: "20 1 * * sat"
     workflow_dispatch:
+    workflow_call:
 
 defaults:
     run:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [pypi package version badge]: https://badge.fury.io/py/astrodata.svg
 [source test status badge]: https://github.com/GeminiDRSoftware/astrodata/actions/workflows/source_tests.yml/badge.svg
 [build test status badge]: https://github.com/GeminiDRSoftware/astrodata/actions/workflows/build_tests.yml/badge.svg
+
 `astrodata`
 =============
 


### PR DESCRIPTION
The `publish_pypi` workflow now runs the source & build tests before publishing, and will fail and abort publishing if any tests fail.