### PR TITLE
Incorporate DRAGONS commits

### DIFF
--- a/astrodata/testing.py
+++ b/astrodata/testing.py
@@ -800,6 +800,7 @@ class ADCompare:
         self.rtol = rtol
         self.atol = atol
         self.ignore_kw = self.fits_keys if ignore_fits_wcs else set([])
+        self.ignore_kw.add("")
 
         if ignore_kw:
             self.ignore_kw.update(ignore_kw)

--- a/astrodata/wcs.py
+++ b/astrodata/wcs.py
@@ -449,6 +449,11 @@ def gwcs_to_fits(ndd, hdr=None):
     # except NameError:
     #     pass
 
+    # TODO: Below comment may not apply, from DRAGONS commit 46177cc
+    # This (commented) line fails for un-invertable Tabular2D
+    crpix = np.array(wcs.backward_transform(*crval)) + 1
+    # crpix = np.array(transform.inverse(*crval)) + 1
+
     # Find any world axes that we previous logarithmed and fix the CDij
     # matrix -- we follow FITS-III (Greisen et al. 2006; A&A 446, 747)
     modified_wcs_center = transform(*pix_center)
@@ -465,11 +470,6 @@ def gwcs_to_fits(ndd, hdr=None):
                 )
 
             crval[world_axis - 1] = np.log(crval[world_axis - 1])
-
-    # TODO: Below comment may not apply, from DRAGONS commit 46177cc
-    # This (commented) line fails for un-invertable Tabular2D
-    crpix = np.array(wcs.backward_transform(*crval)) + 1
-    # crpix = np.array(transform.inverse(*crval)) + 1
 
     # Cope with a situation where the sky projection center is not in the slit
     # We may be able to fix this in future, but FITS doesn't handle it well.

--- a/astrodata/wcs.py
+++ b/astrodata/wcs.py
@@ -350,7 +350,7 @@ def gwcs_to_fits(ndd, hdr=None):
             points = m_this.points
             if not (
                 ndim == 1
-                and np.allclose(points, np.arange(points.size))
+                and np.allclose(points, np.arange(points[0].size))
                 or ndim == 2
                 and np.allclose(points[0], np.arange(points[0].size))
                 and np.allclose(points[1], np.arange(points[1].size))

--- a/astrodata/wcs.py
+++ b/astrodata/wcs.py
@@ -1052,18 +1052,23 @@ def fitswcs_other(header, other=None):
             if other is not None:
                 table_name = header.get(f"PS{ax + 1}_0")
                 table = other.get(table_name)
+
             if table is None:
                 raise ValueError(
                     f"Cannot read table for {ctype} for axis {ax}"
                 )
+
             if isinstance(table, Table):
                 other_model = models.Tabular1D(
-                    lookup_table=table[f"PS{ax + 1}_1"]
+                    lookup_table=table[header[f"PS{ax + 1}_1"]]
                 )
             else:
                 other_model = models.Tabular2D(lookup_table=table.T)
+
             other_model.name = model_name_mapping.get(ctype[:4], ctype[:4])
+
             del other[table_name]
+
         elif len(pixel_axes) == 1:
             pixel_axis = pixel_axes[0]
             m1 = models.Shift(

--- a/astrodata/wcs.py
+++ b/astrodata/wcs.py
@@ -306,12 +306,32 @@ def gwcs_to_fits(ndd, hdr=None):
         # Remove projection parts so we can calculate the CD matrix
         if projcode:
             nat2cel.name = "nat2cel"
+            transform_inverse = transform.inverse.copy()
+
+            for m in transform_inverse:
+                if isinstance(m, models.RotateCelestial2Native):
+                    m.name = "cel2nat"
+
+                elif isinstance(m, models.Sky2PixProjection):
+                    m.name = "sky2pix"
+
+            # TODO(teald): Below comments are from DRAGONS commit 46177cc
+            # transform_inverse = transform_inverse.replace_submodel(
+            #     "cel2nat", models.Identity(2)
+            # )
+            # transform_inverse = transform_inverse.replace_submodel(
+            #     "sky2pix", models.Identity(2)
+            # )
+
             transform = transform.replace_submodel(
                 "pix2sky", models.Identity(2)
             )
             transform = transform.replace_submodel(
                 "nat2cel", models.Identity(2)
             )
+
+            # TODO(teald): Below comments are from DRAGONs commit 46177cc
+            # transform.inverse = transform_inverse
 
     # Replace a log-linear axis with a linear axis representing the log
     # and a Tabular axis with Identity to ensure the affinity check is passed
@@ -421,12 +441,13 @@ def gwcs_to_fits(ndd, hdr=None):
 
     crval = [wcs_dict[f"CRVAL{i+1}"] for i, _ in enumerate(world_axes)]
 
-    try:
-        crval[lon_axis] = 0
-        crval[lat_axis] = 0
+    # TODO: Commented out in DRAGONS commit 46177cc
+    # try:
+    #     crval[lon_axis] = 0
+    #     crval[lat_axis] = 0
 
-    except NameError:
-        pass
+    # except NameError:
+    #     pass
 
     # Find any world axes that we previous logarithmed and fix the CDij
     # matrix -- we follow FITS-III (Greisen et al. 2006; A&A 446, 747)
@@ -445,9 +466,10 @@ def gwcs_to_fits(ndd, hdr=None):
 
             crval[world_axis - 1] = np.log(crval[world_axis - 1])
 
+    # TODO: Below comment may not apply, from DRAGONS commit 46177cc
     # This (commented) line fails for un-invertable Tabular2D
-    # crpix = np.array(wcs.backward_transform(*crval)) + 1
-    crpix = np.array(transform.inverse(*crval)) + 1
+    crpix = np.array(wcs.backward_transform(*crval)) + 1
+    # crpix = np.array(transform.inverse(*crval)) + 1
 
     # Cope with a situation where the sky projection center is not in the slit
     # We may be able to fix this in future, but FITS doesn't handle it well.
@@ -948,9 +970,23 @@ def fitswcs_image(header):
     # create a "ghost" orthogonal axis here so an inverse can be defined
     # Modify the CD matrix in case we have to use a backup Matrix Model later
     if len(pixel_axes) == 1:
-        cd[sky_axes[0], -1] = -cd[sky_axes[1], pixel_axes[0]]
-        cd[sky_axes[1], -1] = cd[sky_axes[0], pixel_axes[0]]
-        sky_cd = cd[np.ix_(sky_axes, pixel_axes + [-1])]
+        # TODO: Below commented code is from DRAGONS commit 46177cc
+        sky_cd = np.array(
+            [
+                [
+                    cd[sky_axes[0], pixel_axes[0]],
+                    -cd[sky_axes[1], pixel_axes[0]],
+                ],
+                [
+                    cd[sky_axes[1], pixel_axes[0]],
+                    cd[sky_axes[0], pixel_axes[0]],
+                ],
+            ]
+        )
+        # cd[sky_axes[0], -1] = -cd[sky_axes[1], pixel_axes[0]]
+        # cd[sky_axes[1], -1] = cd[sky_axes[0], pixel_axes[0]]
+        # sky_cd = cd[np.ix_(sky_axes, pixel_axes + [-1])]
+
         affine = models.AffineTransformation2D(matrix=sky_cd, name="cd_matrix")
         # TODO: replace when PR#10362 is in astropy
         # rotation = models.fix_inputs(affine, {'y': 0})

--- a/astrodata/wcs.py
+++ b/astrodata/wcs.py
@@ -573,19 +573,20 @@ def calculate_affine_matrices(func, shape, origin=None):
     Arguments
     ---------
     func : callable
-        function that maps input->output coordinates
+        Function that maps input->output coordinates; these coordinates
+        are x-first, because "func" is usually an astropy.modeling.Model.
 
     shape : sequence
-        shape to use for fiducial points
+        Shape to use for fiducial points.
 
     origin : sequence/None
-        if a sequence, then use this as the opposite vertex (it must be
-        the same length as "shape")
+        If a sequence, then use this as the opposite vertex (it must be
+        the same length as "shape").
 
     Returns
     -------
     AffineMatrices(array, array)
-        affine matrix and offset
+        Affine matrix and offset.
     """
     indim = len(shape)
     try:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ release = __version__
 
 project = "astrodata"
 copyright = "2023-present, NOIRLab/Gemini Observatories"
-author = ""
+author = "DRAGONS Team"
 
 # -- General configuration ---------------------------------------------------
 
@@ -142,7 +142,6 @@ rst_prolog = """
 
 
 
-.. _`Anaconda`: https://www.anaconda.com/
 .. _`Astropy`: http://docs.astropy.org/en/stable/
 .. _`Conda`: https://conda.io/docs/
 .. _`Numpy`: https://numpy.org/doc/stable/

--- a/noxfile.py
+++ b/noxfile.py
@@ -564,7 +564,7 @@ def dragons_dev_tests(session: nox.Session) -> None:
 def unit_tests(session: nox.Session) -> None:
     """Run the unit tests."""
     install_test_dependencies(session)
-    session.install(".")
+    session.install("-e", ".")
 
     # Positional arguments after -- are passed to pytest.
     pos_args = session.posargs

--- a/noxfile.py
+++ b/noxfile.py
@@ -564,7 +564,7 @@ def dragons_dev_tests(session: nox.Session) -> None:
 def unit_tests(session: nox.Session) -> None:
     """Run the unit tests."""
     install_test_dependencies(session)
-    session.install("-e", ".")
+    session.install("-e", ".", "--no-deps")
 
     # Positional arguments after -- are passed to pytest.
     pos_args = session.posargs
@@ -771,7 +771,7 @@ def build_tests_integration(session):
 def script_tests(session: nox.Session) -> None:
     """Run the script tests."""
     install_test_dependencies(session)
-    session.install(".")
+    session.install("-e", ".", "--no-deps")
 
     # Run the tests. Need to pass arguments to pytest.
     session.run("pytest", "tests/script_tests", *session.posargs)

--- a/tests/unit/test_wcs.py
+++ b/tests/unit/test_wcs.py
@@ -259,10 +259,11 @@ def test_loglinear_axis(NIRI_IMAGE, tmp_path, monkeypatch):
     new_coords = ad[0].wcs(2, 200, 300)
     assert_allclose(coords, new_coords[1:])
 
-    with monkeypatch.chdir(tmp_path):
-        ad.write("test.fits", overwrite=True)
-        ad2 = astrodata.from_file("test.fits")
-        assert_allclose(ad2[0].wcs(2, 200, 300), new_coords)
+    monkeypatch.chdir(tmp_path)
+
+    ad.write("test.fits", overwrite=True)
+    ad2 = astrodata.from_file("test.fits")
+    assert_allclose(ad2[0].wcs(2, 200, 300), new_coords)
 
 @pytest.mark.skip(reason="Requires external test data.")
 @pytest.mark.preprocessed_data
@@ -277,8 +278,9 @@ def test_tabular1D_axis(tmp_path, monkeypatch):
     assert ad[0].wcs(0) == pytest.approx(3017.51065254)
     assert ad[0].wcs(1021) == pytest.approx(4012.89510727)
 
-    with monkeypatch.chdir(tmp_path):
-        ad.write("test.fits", overwrite=True)
-        ad2 = astrodata.open("test.fits")
-        assert ad2[0].wcs(0) == pytest.approx(3017.51065254)
-        assert ad2[0].wcs(1021) == pytest.approx(4012.89510727)
+    monkeypatch.chdir(tmp_path)
+
+    ad.write("test.fits", overwrite=True)
+    ad2 = astrodata.open("test.fits")
+    assert ad2[0].wcs(0) == pytest.approx(3017.51065254)
+    assert ad2[0].wcs(1021) == pytest.approx(4012.89510727)

--- a/tests/unit/test_wcs.py
+++ b/tests/unit/test_wcs.py
@@ -239,7 +239,7 @@ def test_loglinear_axis(NIRI_IMAGE):
     """Test that we can add a log-linear axis and write and read it"""
     ad = astrodata.from_file(NIRI_IMAGE)
     coords = ad[0].wcs(200, 300)
-    ad[0].data = np.repeat(ad[0].data[np.newaxis], 5, axis=0)
+    ad[0].data = np.repeat(ad[0].data[:, :, np.newaxis], 5, axis=2)
     new_input_frame = adwcs.pixel_frame(3)
     loglinear_frame = cf.SpectralFrame(
         axes_order=(0,),

--- a/tests/unit/test_wcs.py
+++ b/tests/unit/test_wcs.py
@@ -263,3 +263,16 @@ def test_loglinear_axis(NIRI_IMAGE):
     ad.write("test.fits", overwrite=True)
     ad2 = astrodata.from_file("test.fits")
     assert_allclose(ad2[0].wcs(2, 200, 300), new_coords)
+
+@pytest.mark.preprocessed_data
+def test_tabular1D_axis(path_to_inputs, change_working_dir):
+    """Check a FITS file with a tabular 1D axis is read correctly and
+    then rewritten to disk and read back in"""
+    ad = astrodata.open(Path(path_to_inputs) / "tab1dtest.fits")
+    assert ad[0].wcs(0) == pytest.approx(3017.51065254)
+    assert ad[0].wcs(1021) == pytest.approx(4012.89510727)
+    with change_working_dir():
+        ad.write("test.fits", overwrite=True)
+        ad2 = astrodata.open("test.fits")
+        assert ad2[0].wcs(0) == pytest.approx(3017.51065254)
+        assert ad2[0].wcs(1021) == pytest.approx(4012.89510727)


### PR DESCRIPTION
# Summary

There have been some commits made to `astrodata` on the main DRAGONS repository that are being ported into `astrodata` in preparation for DRAGONS to include `astrodata` as a dependency.

This PR will require a minor version bump, and when incorporated will become `astrodata` version 2.10.0.

# Changes

+ Fixes to WCS, particularly unused pixel axes.
+ Add test for tabular WCS axes