### PR TITLE
[FIX] Remove deprecated `utcnow`

### DIFF
--- a/astrodata/provenance.py
+++ b/astrodata/provenance.py
@@ -5,7 +5,7 @@ Provides functions for adding provenance information to
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from astropy.table import Table
 
@@ -38,7 +38,7 @@ def add_provenance(ad, filename, md5, primitive, timestamp=None):
     md5 = "" if md5 is None else md5
 
     if timestamp is None:
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
 
     if hasattr(ad, "PROVENANCE"):
         existing_provenance = ad.PROVENANCE

--- a/astrodata/provenance.py
+++ b/astrodata/provenance.py
@@ -38,7 +38,7 @@ def add_provenance(ad, filename, md5, primitive, timestamp=None):
     md5 = "" if md5 is None else md5
 
     if timestamp is None:
-        timestamp = datetime.now(timezone.utc).isoformat()
+        timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
 
     if hasattr(ad, "PROVENANCE"):
         existing_provenance = ad.PROVENANCE

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 import os
 
@@ -31,7 +31,7 @@ def ad2():
 
 
 def test_add_get_provenance(ad):
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "provenance_added_by"
@@ -58,7 +58,7 @@ def test_add_get_provenance(ad):
 
 
 def test_add_duplicate_provenance(ad):
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "provenance_added_by"
@@ -71,7 +71,7 @@ def test_add_duplicate_provenance(ad):
 
 
 def test_add_get_history(ad):
-    timestamp_start = datetime.utcnow()
+    timestamp_start = datetime.now(timezone.utc)
     timestamp_end = (timestamp_start + timedelta(days=1)).isoformat()
     timestamp_start = timestamp_start.isoformat()
     primitive = "primitive"
@@ -103,7 +103,7 @@ def test_add_get_history(ad):
 
 
 def test_add_dupe_history(ad):
-    timestamp_start = datetime.utcnow()
+    timestamp_start = datetime.now(timezone.utc)
     timestamp_end = (timestamp_start + timedelta(days=1)).isoformat()
     timestamp_start = timestamp_start.isoformat()
     primitive = "primitive"
@@ -117,7 +117,7 @@ def test_add_dupe_history(ad):
 
 
 def test_clone_provenance(ad, ad2):
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "provenance_added_by"
@@ -131,7 +131,7 @@ def test_clone_provenance(ad, ad2):
 
 
 def test_clone_history(ad, ad2):
-    timestamp_start = datetime.utcnow()
+    timestamp_start = datetime.now(timezone.utc)
     timestamp_end = (timestamp_start + timedelta(days=1)).isoformat()
     timestamp_start = timestamp_start.isoformat()
     primitive = "primitive"
@@ -167,7 +167,7 @@ def test_convert_provhistory(tmp_path, BPM_PROVHISTORY):
     assert hasattr(ad, "PROVHISTORY")
 
     # When we add history, that should get converted to HISTORY
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     add_history(ad, now, now, "primitive", "args")
     assert not hasattr(ad, "PROVHISTORY")
     assert hasattr(ad, "HISTORY")
@@ -195,26 +195,26 @@ def test_provenance_summary(ad):
     summary = astrodata.provenance.provenance_summary(ad).casefold()
     assert "no provenance" in summary
 
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "primitive_name"
 
     add_provenance(ad, filename, md5, primitive, timestamp=timestamp)
 
-    timestamp_end = datetime.utcnow().isoformat()
+    timestamp_end = datetime.now(timezone.utc).isoformat()
     args = json.dumps({"arg1": 1, "arg2": 3})
 
     add_history(ad, timestamp, timestamp_end, primitive, args)
 
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "snudder_primitive_name"
 
     add_provenance(ad, filename, md5, primitive, timestamp=timestamp)
 
-    timestamp_end = datetime.utcnow().isoformat()
+    timestamp_end = datetime.now(timezone.utc).isoformat()
     args = json.dumps({"arg1": 1, "arg2": 2})
 
     add_history(ad, timestamp, timestamp_end, primitive, args)

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -31,7 +31,7 @@ def ad2():
 
 
 def test_add_get_provenance(ad):
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "provenance_added_by"
@@ -58,7 +58,7 @@ def test_add_get_provenance(ad):
 
 
 def test_add_duplicate_provenance(ad):
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "provenance_added_by"
@@ -71,7 +71,7 @@ def test_add_duplicate_provenance(ad):
 
 
 def test_add_get_history(ad):
-    timestamp_start = datetime.now(timezone.utc)
+    timestamp_start = datetime.now(timezone.utc).replace(tzinfo=None)
     timestamp_end = (timestamp_start + timedelta(days=1)).isoformat()
     timestamp_start = timestamp_start.isoformat()
     primitive = "primitive"
@@ -103,7 +103,7 @@ def test_add_get_history(ad):
 
 
 def test_add_dupe_history(ad):
-    timestamp_start = datetime.now(timezone.utc)
+    timestamp_start = datetime.now(timezone.utc).replace(tzinfo=None)
     timestamp_end = (timestamp_start + timedelta(days=1)).isoformat()
     timestamp_start = timestamp_start.isoformat()
     primitive = "primitive"
@@ -117,7 +117,7 @@ def test_add_dupe_history(ad):
 
 
 def test_clone_provenance(ad, ad2):
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "provenance_added_by"
@@ -131,7 +131,7 @@ def test_clone_provenance(ad, ad2):
 
 
 def test_clone_history(ad, ad2):
-    timestamp_start = datetime.now(timezone.utc)
+    timestamp_start = datetime.now(timezone.utc).replace(tzinfo=None)
     timestamp_end = (timestamp_start + timedelta(days=1)).isoformat()
     timestamp_start = timestamp_start.isoformat()
     primitive = "primitive"
@@ -167,7 +167,7 @@ def test_convert_provhistory(tmp_path, BPM_PROVHISTORY):
     assert hasattr(ad, "PROVHISTORY")
 
     # When we add history, that should get converted to HISTORY
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
     add_history(ad, now, now, "primitive", "args")
     assert not hasattr(ad, "PROVHISTORY")
     assert hasattr(ad, "HISTORY")
@@ -195,26 +195,26 @@ def test_provenance_summary(ad):
     summary = astrodata.provenance.provenance_summary(ad).casefold()
     assert "no provenance" in summary
 
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "primitive_name"
 
     add_provenance(ad, filename, md5, primitive, timestamp=timestamp)
 
-    timestamp_end = datetime.now(timezone.utc).isoformat()
+    timestamp_end = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
     args = json.dumps({"arg1": 1, "arg2": 3})
 
     add_history(ad, timestamp, timestamp_end, primitive, args)
 
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
     filename = "filename"
     md5 = "md5"
     primitive = "snudder_primitive_name"
 
     add_provenance(ad, filename, md5, primitive, timestamp=timestamp)
 
-    timestamp_end = datetime.now(timezone.utc).isoformat()
+    timestamp_end = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
     args = json.dumps({"arg1": 1, "arg2": 2})
 
     add_history(ad, timestamp, timestamp_end, primitive, args)


### PR DESCRIPTION
This still fails some tests because of differences in 3.12. There's also an issue with times being truncated, which may be a formatting issue that cannot be addressed right now (see below).

This closes Issue #17 

## Truncated times issue

When running the 3.12 tests, get an initial failure at:
```text
FAILED tests/unit/test_provenance.py::test_add_get_history - AssertionError: assert ('primitive', 'args', '2024-10-10T22:30:21.654469
+0', '2024-10-11T22:30:21.654469+0') == ('primitive', 'args', '2024-10-10T22:30:21.654469+00:00', '2024-10-11T22:30:21.654469+00:00')
  
  At index 2 diff: '2024-10-10T22:30:21.654469+0' != '2024-10-10T22:30:21.654469+00:00'
  
  Full diff:
    (
        'primitive',
        'args',
  -     '2024-10-10T22:30:21.654469+00:00',
  ?                                  ----
  +     '2024-10-10T22:30:21.654469+0',
  -     '2024-10-11T22:30:21.654469+00:00',
  ?                                  ----
  +     '2024-10-11T22:30:21.654469+0',
    )
```

This likely has to do with truncation happening that was not previously supported. I'm not sure if this is a limitation of FITS, `astrodata`, or something else at this point.

# TODO

- [x] Compare previous outputs directly.
  - [x] Turn this into a test, to test for updates to any time formatting moving forward
  - [x] Have single function for generating time strings? mostly affects `astrodata/provenance.py`