### PR TITLE
Update devshell packages for "all"

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -109,7 +109,19 @@ jobs:
 
         steps:
             - uses: "actions/checkout@v4"
-            - uses: excitedleigh/setup-nox@v2.0.0
+            - name: "Set up Python"
+              uses: "actions/setup-python@v5"
+              with:
+                  python-version: |
+                    3.10
+                    3.11
+                    3.12
+
+            - name: "Install top-level dependencies"
+              run: |
+                  python -m pip install --upgrade pip
+                  python -m pip install nox poetry
+
             - uses: conda-incubator/setup-miniconda@v3
               with:
                 python-version: "${{ matrix.python-version }}"
@@ -117,8 +129,7 @@ jobs:
 
             - name: "Install and update pip"
               run: |
-                  conda install -c conda-forge pip python=${{ matrix.python-version }} -y
-                  pip install --upgrade pip poetry
+                  conda install -c conda-forge pip "python=${{ matrix.python-version }}" -y
 
             - name: "Integration tests"
               run: nox -s build_tests_integration -x -- -vv

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -113,6 +113,7 @@ jobs:
             - uses: conda-incubator/setup-miniconda@v3
               with:
                 python-version: "${{ matrix.python-version }}"
+                conda-remove-defaults: "true"
 
             - name: "Install and update pip"
               run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -112,10 +112,7 @@ jobs:
             - name: "Set up Python"
               uses: "actions/setup-python@v5"
               with:
-                  python-version: |
-                    3.10
-                    3.11
-                    3.12
+                  python-version: ${{ matrix.python-version }}
 
             - name: "Install top-level dependencies"
               run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -116,7 +116,7 @@ jobs:
 
             - name: "Install and update pip"
               run: |
-                  conda install -c conda-forge pip
+                  conda install -c conda-forge pip python=${{ matrix.python-version }} -y
                   pip install --upgrade pip poetry
 
             - name: "Integration tests"

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -52,6 +52,7 @@ To install |astrodata|, you will need the following:
 
 - Python 3.10, 3.11, or 3.12
 - Poetry_ in some flavor
+- ``poetry-plugin-export``, installed into the same environment as Poetry_
 - Nox_ (optional, see note below)
 
 Please see the Poetry_ and nox_ documentation for installation instructions.
@@ -62,7 +63,15 @@ their documentation.
 .. _pipx: https://pipx.pypa.io/stable/
 
 We recommend using pipx_ to install Poetry and nox, as it will install them in
-isolated environments and make them easier to manage.
+isolated environments and make them easier to manage. If you're using `pipx`,
+you only need to copy/paste the following lines to ensure you have everything
+installed properly:
+
+.. code-block:: shell
+
+   pipx install poetry
+   poetry self add poetry-plugin-export
+   pipx install nox
 
 .. note::
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -818,7 +818,6 @@ def devshell(session: nox.Session) -> None:
     """Create a venv for development."""
     # Installing poetry within this isolated env to avoid having devs manage
     # installing a plugin...
-    session.install("poetry", "poetry-plugin-export")
     session.env["POETRY_PREFER_ACTIVE_PYTHON"] = "true"
     session.env["POETRY_VIRTUALENVS_CREATE"] = "false"
 
@@ -827,7 +826,7 @@ def devshell(session: nox.Session) -> None:
 
     # Check that poetry is installed
     try:
-        session.run("poetry", "--version", silent=True)
+        session.run("poetry", "--version", silent=True, external=True)
 
     except nox.command.CommandFailed as err:
         message_lines = (
@@ -892,7 +891,7 @@ def devshell(session: nox.Session) -> None:
     session.notify("initialize_pre_commit")
 
 
-@nox.session(venv_backend="none")
+@nox.session(venv_backend="conda")
 def devconda(session: nox.Session) -> None:
     """Create a new conda environment for development."""
     conda_venv_name = "astrodata"
@@ -952,7 +951,15 @@ def devconda(session: nox.Session) -> None:
     session.run("conda", "update", "-n", conda_venv_name, "--all", "--yes")
 
     conda_python = conda_envs_loc / conda_venv_name / "bin" / "python"
-    session.run(str(conda_python), "-m", "pip", "install", "--upgrade", "pip")
+    session.run(
+        str(conda_python),
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "pip",
+        external=True,
+    )
 
     session.run(
         str(conda_python),
@@ -961,6 +968,7 @@ def devconda(session: nox.Session) -> None:
         "install",
         "--requirement",
         str(req_file_path),
+        external=True,
     )
 
     # Install the package in editable mode
@@ -972,6 +980,7 @@ def devconda(session: nox.Session) -> None:
         "-e",
         ".",
         "--no-deps",
+        external=True,
     )
 
     session.log("Conda environment created.")

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,13 +19,14 @@ import nox
 if sys.version_info[1] > 11:
     import tomllib
 
-elif sys.version_info[1] < 10:
+elif sys.version_info[0] < 3 or sys.version_info[1] < 10:
     major, minor = sys.version_info[0], sys.version_info[1]
     py_version = f"{major}.{minor}"
     raise Exception(f"Python version below 3.10 (using {py_version})")
 
 else:
-    # Only for python 3.10 support
+    # Only for python 3.10 support, which wont' be maintained much longer.
+    # To be removed when we drop support for python 3.10 (see: ISSUE)
     from pip._vendor import tomli
 
     tomllib = tomli

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,23 @@ from pathlib import Path
 from typing import ClassVar
 
 import nox
-import tomllib
+
+# Logic required because tomllib was introduced to the standard library in
+# python version 3.11.
+if sys.version_info[1] > 11:
+    import tomllib
+
+elif sys.version_info[1] < 10:
+    major, minor = sys.version_info[0], sys.version_info[1]
+    py_version = f"{major}.{minor}"
+    raise Exception(f"Python version below 3.10 (using {py_version})")
+
+else:
+    # Only for python 3.10 support
+    from pip._vendor import tomli
+
+    tomllib = tomli
+
 
 # Nox configuration
 # Default nox sessions to run when executing "nox" without session


### PR DESCRIPTION
# Summary

The developer shells was not properly installing all groups, as `poetry install` does. This PR fixes that problem.

# Changes

+ Updates the "all" boolean flag to catch all groups in `pyproject.toml` and use all of them when exporting with poetry to a `requirements.txt`
+ `devshell` and `devconda` sessions no longer run without a `venv_backend`
+ Updates documentation to make Poetry installation instructions clearer, with copy/paste commands.