### PR TITLE
Allow Section.from_string to handle None

### DIFF
--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -474,7 +474,15 @@ class Section(tuple):
 
     @staticmethod
     def from_string(value):
-        """Produce a Section object from a string."""
+        """Produce a Section object from a string.
+
+        Arguments
+        ---------
+
+        value: str | None
+            String from which to create a new Section object. If None, it will
+            return None.
+        """
         if value is None:
             return None
 

--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -475,6 +475,9 @@ class Section(tuple):
     @staticmethod
     def from_string(value):
         """Produce a Section object from a string."""
+        if value is None:
+            return None
+
         return Section(
             *[
                 y


### PR DESCRIPTION
# Summary

Adds handling for `None` input to `Section.from_string`. Minimal example:

```python
from astrodata.utils import Section

from pathlib import Path

file_path = Path("/file/that/does/not/exist.txt")  # In reality, some FITS stuff
string = file_path.read_text() if file_path.exists() else None
section = Section.from_string(string)  # Previously raised exception
```

This is what DRAGONS expects, and was previously implemented there. 

This also adds relevant information to the `Section.from_string` docstring.