### PR TITLE
Bring in DRAGONS feature changes

### DIFF
--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -8,7 +8,7 @@ import textwrap
 import warnings
 from collections import OrderedDict
 from contextlib import suppress
-from copy import deepcopy
+from copy import copy, deepcopy
 from functools import partial
 
 import numpy as np
@@ -134,6 +134,9 @@ class AstroData:
         if nddata is None:
             nddata = []
 
+        elif not isinstance(nddata, (list, tuple)):
+            nddata = [nddata]
+
         # Check that nddata is either a single or iterable of NDAstroData
         # objects
         is_nddata = isinstance(nddata, NDAstroData)
@@ -180,6 +183,24 @@ class AstroData:
         self._logger = logging.getLogger(__name__)
         self._orig_filename = None
         self._path = None
+
+    def __copy__(self):
+        """Return a shallow copy of this instance."""
+        obj = self.__class__()
+
+        for attr in ("_phu", "_path", "_orig_filename", "_tables"):
+            obj.__dict__[attr] = self.__dict__[attr]
+
+        # A new list containing references (rather than a reference to the
+        # list).
+        obj.__dict__["_all_nddatas"] = [nd for nd in self._nddata]
+
+        # If we're copying a single-slice AD, then make its NDAstroData a copy
+        # so attributes can be modified without affecting the original
+        if self.is_single:
+            obj.__dict__["_all_nddatas"][self._indices[0]] = copy(self.nddata)
+
+        return obj
 
     def __deepcopy__(self, memo):
         """Return a new instance of this class.

--- a/astrodata/nddata.py
+++ b/astrodata/nddata.py
@@ -713,5 +713,16 @@ class NDAstroData(AstroDataMixin, NDArithmeticMixin, NDSlicingMixin, NDData):
             uncertainty=None if unc is None else unc.__class__(unc.array.T),
             mask=None if self.mask is None else self.mask.T,
             wcs=new_wcs,
+            meta=self.meta,
             copy=False,
         )
+
+    def _slice(self, item):
+        """Slice metadata like OBJMASK."""
+        kwargs = super()._slice(item)
+        if "other" in kwargs["meta"]:
+            kwargs["meta"] = deepcopy(self.meta)
+            for k, v in kwargs["meta"]["other"].items():
+                if isinstance(v, np.ndarray) and v.shape == self.shape:
+                    kwargs["meta"]["other"][k] = v[item]
+        return kwargs

--- a/astrodata/testing.py
+++ b/astrodata/testing.py
@@ -897,14 +897,23 @@ class ADCompare:
         errorlist = []
         s1 = set(hdr1.keys()) - {"HISTORY", "COMMENT"}
         s2 = set(hdr2.keys()) - {"HISTORY", "COMMENT"}
+
         if ignore:
             s1 -= set(ignore)
             s2 -= set(ignore)
+
         if s1 != s2:
             if s1 - s2:
                 errorlist.append(f"Header 1 contains keywords {s1 - s2}")
+
             if s2 - s1:
                 errorlist.append(f"Header 2 contains keywords {s2 - s1}")
+
+        ignore_list = ["GEM-TLM", "HISTORY", "COMMENT", ""]
+
+        # Include keywords from `ignore` parameter.
+        if ignore:
+            ignore_list.extend(ignore)
 
         # If present, import timestamp_keys from geminidr.gemini.lookups
         # to compare the timestamps in the headers.
@@ -920,7 +929,7 @@ class ADCompare:
             # GEM-TLM is "time last modified"
             if (
                 kw not in timestamp_keys.values()
-                and kw not in ["GEM-TLM", "HISTORY", "COMMENT", ""]
+                and kw not in ignore_list
                 and kw not in self.ignore_kw
             ):
                 try:

--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -517,6 +517,13 @@ class Section(tuple):
         For example,
         >>> Section(0, 10, 0, 10).as_iraf_section()
         '[1:10,1:10]'
+
+        Arguments
+        ---------
+        binning : iterable
+            A length-2 iterable of (x_binning, y_binning). Binning is assumed
+            to be 1 for all axes if not given.
+
         """
         if binning is None:
             binning = [1] * len(self._axis_names)

--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -527,14 +527,15 @@ class Section(tuple):
         """
         if binning is None:
             binning = [1] * len(self._axis_names)
+
         return (
             "["
             + ",".join(
                 [
                     ":".join(
                         [
-                            str(bin_ * self.__dict__[axis] + 1),
-                            str(bin_ * self.__dict__[axis.replace("1", "2")]),
+                            str(bin_ * self.axis_dict[axis] + 1),
+                            str(bin_ * self.axis_dict[axis.replace("1", "2")]),
                         ]
                     )
                     for axis, bin_ in zip(self._axis_names[::2], binning)

--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -502,14 +502,14 @@ class Section(tuple):
         "Renamed to 'as_iraf_section', this is just an alias for now "
         "and will be removed in a future version."
     )
-    def asIRAFsection(self):  # pylint: disable=invalid-name
+    def asIRAFsection(self, binning=None):  # pylint: disable=invalid-name
         """Produce string with '[x1:x2,y1:y2]' 1-indexed and end-inclusive.
 
         Deprecated, see :py:meth:`~astrodata.Section.as_iraf_section`.
         """
         return self.as_iraf_section()
 
-    def as_iraf_section(self):
+    def as_iraf_section(self, binning=None):
         """Produce string with '[x1:x2,y1:y2]' 1-indexed and end-inclusive.
 
         This is the format used by IRAF for sections.
@@ -518,17 +518,19 @@ class Section(tuple):
         >>> Section(0, 10, 0, 10).as_iraf_section()
         '[1:10,1:10]'
         """
+        if binning is None:
+            binning = [1] * len(self._axis_names)
         return (
             "["
             + ",".join(
                 [
                     ":".join(
                         [
-                            str(self.axis_dict[axis] + 1),
-                            str(self.axis_dict[axis.replace("1", "2")]),
+                            str(bin_ * self.__dict__[axis] + 1),
+                            str(bin_ * self.__dict__[axis.replace("1", "2")]),
                         ]
                     )
-                    for axis in self._axis_names[::2]
+                    for axis, bin_ in zip(self._axis_names[::2], binning)
                 ]
             )
             + "]"

--- a/astrodata/wcs.py
+++ b/astrodata/wcs.py
@@ -1008,13 +1008,11 @@ def fitswcs_image(header):
         rotation = models.AffineTransformation2D(
             matrix=sky_cd, name="cd_matrix"
         )
-    transforms.append(rotation)
 
     # Do it this way so the whole CD matrix + projection is separable
     projection = gwutils.fitswcs_nonlinear(wcs_info)
 
     if projection:
-        transforms.append(projection)
         rotation |= projection
 
     transforms.append(rotation)

--- a/astrodata/wcs.py
+++ b/astrodata/wcs.py
@@ -1010,9 +1010,14 @@ def fitswcs_image(header):
         )
     transforms.append(rotation)
 
+    # Do it this way so the whole CD matrix + projection is separable
     projection = gwutils.fitswcs_nonlinear(wcs_info)
+
     if projection:
         transforms.append(projection)
+        rotation |= projection
+
+    transforms.append(rotation)
 
     sky_model = functools.reduce(lambda x, y: x | y, transforms)
     sky_model.name = "SKY"
@@ -1384,3 +1389,78 @@ def remove_unused_world_axis(ext):
         )
 
     ext.wcs = gWCS(new_pipeline)
+
+
+def create_new_image_projection(transform, new_center):
+    """Modify a transform so the projection center is at new_center.
+
+    Modifies a simple imaging transform::
+
+        (
+            (Shift & Shift)
+            | AffineTransformation2D
+            | Pix2Sky
+            | RotateNative2Celestial
+        )
+
+    so that the projection center is in a different sky location
+
+    This works by rotating the AffineTransformation2D.matrix by the change in
+    angle (in Euclidean geometry) to the pole when moving from the original
+    projection center to the new one. The sign of this angle depends on whether
+    East is to the left or right when North is up. This works even when the
+    pole is on the image.
+
+    This is accurate to <0.1 arcsec for shifts of up to 1 degree
+
+    Arguments
+    ---------
+    transform: Model
+        current forward imaging transform
+
+    new_center: tuple
+        (RA, DEC) coordinates of new projection center
+
+    Returns
+    -------
+    Model: a transform that is projected around the new center
+
+    """
+    assert isinstance(transform[-1], models.RotateNative2Celestial)
+    assert isinstance(transform[-3], models.AffineTransformation2D)
+
+    current_center = transform[-1].lon.value, transform[-1].lat.value
+    xc, yc = transform.inverse(*current_center)
+    xcnew, ycnew = transform.inverse(*new_center)
+    xpole, ypole = transform.inverse(0, 90)
+
+    # astropy >=5.2 returns NaNs for a point not in the same hemisphere as
+    # the projection centre, so use the Celestial South Pole if required
+    if np.isnan(xpole) or np.isnan(ypole):
+        xpole, ypole = transform.inverse(0, -90)
+
+    angle1 = np.arctan2(xpole - xc, ypole - yc)
+    angle2 = np.arctan2(xpole - xcnew, ypole - ycnew)
+    rotation = (angle1 - angle2) * 180 / np.pi
+    matrix = transform[-3].matrix
+
+    # flipped means East is to the right when North is up
+    flipped = (
+        matrix[0, 0] * matrix[1, 1] > 0 or matrix[0, 1] * matrix[1, 0] < 0
+    )
+
+    new_transform = deepcopy(transform[-3:])
+
+    new_transform[0].matrix = models.Rotation2D(
+        -rotation if flipped else rotation
+    )(*matrix)
+
+    new_transform[-1].lon, new_transform[-1].lat = new_center
+
+    shifts = models.Shift(-xcnew, name="crpix1") & models.Shift(
+        -ycnew, name="crpix2"
+    )
+
+    new_transform = shifts | new_transform
+
+    return new_transform

--- a/tests/unit/test_nddata.py
+++ b/tests/unit/test_nddata.py
@@ -375,6 +375,18 @@ def test__get_uncertainty(testnd):
     assert isinstance(result, ADVarianceUncertainty)
     assert_array_equal(result.array, testnd.variance[:2, 0])
 
+# Basically the same test as above but using slicing.
+def test_access_to_other_planes_when_sliced(testnd):
+    ndwindow = testnd[1:, 1:]
+    assert ndwindow.data.shape == (4, 4)
+    assert ndwindow.data[0, 0] == testnd.shape[1] + 1
+    assert ndwindow.OBJMASK.shape == (4, 4)
+    assert ndwindow.OBJMASK[0, 0] == testnd.shape[1] + 1
+    assert isinstance(ndwindow.OBJCAT, Table)
+    assert len(ndwindow.OBJCAT) == 3
+
+
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/unit/test_wcs.py
+++ b/tests/unit/test_wcs.py
@@ -284,3 +284,28 @@ def test_tabular1D_axis(tmp_path, monkeypatch):
     ad2 = astrodata.open("test.fits")
     assert ad2[0].wcs(0) == pytest.approx(3017.51065254)
     assert ad2[0].wcs(1021) == pytest.approx(4012.89510727)
+
+# Coordinates of projection center and new projection center
+@pytest.mark.parametrize("coords", ([(0, 0), (0.1, -0.1)],
+                                    [(120, -50), (119.5, -49.5)],
+                                    [(270, 89.9), (0, 89)]))
+@pytest.mark.parametrize("flip", (True, False))
+def test_create_new_image_projection(flip, coords):
+    shifts = (100, 200)
+    shifts = models.Shift(shifts[0]) & models.Shift(shifts[1])
+    pixscale = 1.0
+    angle = 0
+    matrix = np.asarray(models.Rotation2D(angle)(*(np.identity(2) * pixscale / 3600)))
+    if not flip:
+        matrix[0] *= -1
+    lon, lat = coords[0]
+    projection = (models.AffineTransformation2D(matrix=matrix) |
+                  models.Pix2Sky_Gnomonic() |
+                  models.RotateNative2Celestial(lon=lon, lat=lat, lon_pole=180))
+    transform = shifts | projection
+    new_transform = adwcs.create_new_image_projection(transform, coords[1])
+    for x in (0, 1000):
+        for y in (0, 1000):
+            c1 = SkyCoord(*transform(x, y), unit='deg')
+            c2 = SkyCoord(*new_transform(x, y), unit='deg')
+            assert c1.separation(c2).arcsec < 0.5


### PR DESCRIPTION
# Summary

Recent [changes to the development version of DRAGONS](https://github.com/GeminiDRSoftware/DRAGONS/compare/release/3.2.x...master) due to feature merges incorporating changes from 2+ years of commits have brought `astrodata` out of sync with DRAGONS in unexpected ways.

This PR attempts to capture the changes, especially in tests. They're being brought in together to avoid some overhead.

## Changes

+ Updated shallow copying for `AstroData` objects
+ Metadata slicing for `AstroNDData` objects
+ Update ignored keys handling in `testing.ADCompare._header`
+ Add `None` handling to binning in `utils.as_iraf_section`
  + Differs from how `DRAGONS` does this because `DRAGONS`'s version of `astrodata` still uses a bad `__dict__` override that's been fixed in this `astrodata` for a while
+ Add `wcs.create_new_image_projection`
+ Update `wcs.fitswcs_image` to include rotation

### Tests

+ Add `test_access_to_other_planes_when_sliced` to `tests/unit/test_nddata.py`
+ Add `test_create_new_image_projection` to `tests/unit/test_wcs.py`

### Documentation

+ Update `utils.as_iraf_section` docstring to include `binning` argument

