### PR TITLE
Use poetry-plugin-export during workflows

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -111,6 +111,7 @@ jobs:
 
         steps:
             - uses: "actions/checkout@v4"
+
             - name: "Set up Python"
               uses: "actions/setup-python@v5"
               with:
@@ -129,7 +130,7 @@ jobs:
 
             - name: "Install and update pip"
               run: |
-                  conda install -c conda-forge pip "python=${{ matrix.python-version }}" -y
+                  conda install -c conda-forge pip "python=${{ matrix.python-version }}" -y --quiet
 
             - name: "Integration tests"
               run: nox -s build_tests_integration -x -- -vv

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -42,6 +42,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   python -m pip install nox poetry
+                  poetry self add poetry-plugin-export
 
             - name: "Unit tests"
               run: nox -s build_tests_unit -x -- -vv
@@ -74,6 +75,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   python -m pip install nox poetry
+                  poetry self add poetry-plugin-export
 
             - name: "Get public IP address of runner"
               # Need to handle this for Windows, MacOS, and linux
@@ -118,6 +120,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   python -m pip install nox poetry
+                  poetry self add poetry-plugin-export
 
             - uses: conda-incubator/setup-miniconda@v3
               with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install poetry nox
+          poetry self add poetry-plugin-export
       - name: Sphinx build
         run: |
           nox -s docs

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -43,6 +43,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   python -m pip install nox poetry
+                  poetry self add poetry-plugin-export
 
             - name: "Get public IP address of runner"
               # Need to handle this for Windows, MacOS, and linux
@@ -94,6 +95,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   python -m pip install nox poetry
+                  poetry self add poetry-plugin-export
 
             - name: "Get public IP address of runner"
               # Need to handle this for Windows, MacOS, and linux
@@ -155,6 +157,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   python -m pip install nox poetry
+                  poetry self add poetry-plugin-export
 
             - name: "DRAGONS release tests"
               run: |

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -63,7 +63,7 @@ jobs:
                   python -m nox -r -vv
 
             - name: "Upload coverage data"
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: covdata
                   path: .coverage.*
@@ -115,7 +115,7 @@ jobs:
                   python -m nox -s script_tests --verbose -x -- -xvv
 
             # - name: "Upload coverage data"
-            #   uses: actions/upload-artifact@v3
+            #   uses: actions/upload-artifact@v4
             #   with:
             #       name: covdata
             #       path: .coverage.*
@@ -179,7 +179,7 @@ jobs:
                 echo "immediately."
 
             - name: "Upload coverage data"
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: covdata
                   path: .coverage.*

--- a/noxfile.py
+++ b/noxfile.py
@@ -657,7 +657,7 @@ def integration_test_build(session: nox.Session) -> None:
 
     # Need to downgrade numpy because of DRAGONS issue 464
     # https://github.com/GeminiDRSoftware/DRAGONS/issues/464
-    session.conda_install("numpy<2")
+    session.run("conda", "install", "numpy<2", "-y")
 
     session.install("astrodata")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -569,7 +569,7 @@ def dragons_dev_tests(session: nox.Session) -> None:
 
     # Need to downgrade numpy because of DRAGONS issue 464
     # https://github.com/GeminiDRSoftware/DRAGONS/issues/464
-    session.conda_install("numpy<2")
+    session.conda_install("numpy==1.7")
 
     session.install("-e", f"{SessionVariables.noxfile_dir()}", "--no-deps")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -657,8 +657,7 @@ def integration_test_build(session: nox.Session) -> None:
 
     # Need to downgrade numpy because of DRAGONS issue 464
     # https://github.com/GeminiDRSoftware/DRAGONS/issues/464
-    session.run("conda", "install", "numpy<2", "-y")
-
+    session.conda_install("numpy==1.7")
     session.install("astrodata")
 
     # Positional arguments after -- are passed to pytest.

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,7 +57,7 @@ class SessionVariables:
         "astropy>=6",
         "astroquery",
         "matplotlib",
-        "numpy==1.6",
+        "numpy==1.26.*",
         "psutil",
     ]
 
@@ -495,7 +495,7 @@ def dragons_release_tests(session: nox.Session) -> None:
 
     # Need to downgrade numpy because of DRAGONS issue 464
     # https://github.com/GeminiDRSoftware/DRAGONS/issues/464
-    session.conda_install("numpy<2")
+    session.conda_install("numpy=1.26")
 
     session.install("-e", f"{SessionVariables.noxfile_dir()}", "--no-deps")
 
@@ -569,7 +569,7 @@ def dragons_dev_tests(session: nox.Session) -> None:
 
     # Need to downgrade numpy because of DRAGONS issue 464
     # https://github.com/GeminiDRSoftware/DRAGONS/issues/464
-    session.conda_install("numpy=1.6")
+    session.conda_install("numpy=1.26")
 
     session.install("-e", f"{SessionVariables.noxfile_dir()}", "--no-deps")
 
@@ -657,7 +657,7 @@ def integration_test_build(session: nox.Session) -> None:
 
     # Need to downgrade numpy because of DRAGONS issue 464
     # https://github.com/GeminiDRSoftware/DRAGONS/issues/464
-    session.conda_install("numpy=1.6")
+    session.conda_install("numpy=1.26")
     session.install("astrodata")
 
     # Positional arguments after -- are passed to pytest.

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,7 +57,7 @@ class SessionVariables:
         "astropy>=6",
         "astroquery",
         "matplotlib",
-        "numpy<2",
+        "numpy==1.6",
         "psutil",
     ]
 
@@ -569,7 +569,7 @@ def dragons_dev_tests(session: nox.Session) -> None:
 
     # Need to downgrade numpy because of DRAGONS issue 464
     # https://github.com/GeminiDRSoftware/DRAGONS/issues/464
-    session.conda_install("numpy==1.7")
+    session.conda_install("numpy=1.6")
 
     session.install("-e", f"{SessionVariables.noxfile_dir()}", "--no-deps")
 
@@ -657,7 +657,7 @@ def integration_test_build(session: nox.Session) -> None:
 
     # Need to downgrade numpy because of DRAGONS issue 464
     # https://github.com/GeminiDRSoftware/DRAGONS/issues/464
-    session.conda_install("numpy==1.7")
+    session.conda_install("numpy=1.6")
     session.install("astrodata")
 
     # Positional arguments after -- are passed to pytest.

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -850,6 +850,10 @@ def test_ADCompare_unequal_tags(tmp_path):
 
         assert compare_obj.tags()
 
+    for _ad in [ad1, ad2, ad3]:
+        compare_obj = testing.ADCompare(_ad, _ad)
+
+        assert not compare_obj.tags()
 
 
 def test_ADCompare_header_matching(ad1, ad2):


### PR DESCRIPTION
# Summary

Adds overlooked `poetry self add poetry-plugin-export` to workflow files. Now that Poetry 2 is being pulled with fresh installs, `poetry export` is officially deprecated.

## Notes

+ No release required (only CI changes)
+ Closes Issue #80 