### PR TITLE
[FIX] Update error handling in adfactory

### DIFF
--- a/astrodata/adfactory.py
+++ b/astrodata/adfactory.py
@@ -89,6 +89,12 @@ class AstroDataFactory:
                     raise
 
                 except Exception as err:  # noqa
+                    LOGGER.debug(
+                        "Failed to open %s with %s, got error: %s",
+                        source,
+                        func,
+                        err,
+                    )
                     exception_list.append(
                         (
                             func.__name__,
@@ -204,6 +210,13 @@ class AstroDataFactory:
                     raise
 
                 except Exception as err:
+                    LOGGER.debug(
+                        "Failed to open %s with %s, got error: %s",
+                        source,
+                        adclass,
+                        err,
+                    )
+
                     exception_list.append(
                         (
                             adclass.__name__,

--- a/astrodata/adfactory.py
+++ b/astrodata/adfactory.py
@@ -84,6 +84,9 @@ class AstroDataFactory:
                 except KeyboardInterrupt:
                     raise
 
+                except FileNotFoundError:
+                    raise
+
                 except Exception as err:  # noqa
                     LOGGER.error(
                         "Failed to open %s with %s, got error: %s",
@@ -91,13 +94,6 @@ class AstroDataFactory:
                         func,
                         err,
                     )
-
-                    # Handle nonexistent files.
-                    # TODO: Factor this out into a higher except statement.
-                    if isinstance(err, FileNotFoundError):
-                        raise err
-
-                    print(type(err), err)
 
                 else:
                     if hasattr(fp, "close"):


### PR DESCRIPTION
# Summary

In DRAGONS, exceptions caught during certain critical `AstroDataFactory` methods, like `._open_file` and `.get_astro_data` were discarded. This caused problems with testing, debugging, and maintenance of `astrodata`. It also makes development (with or of) `astrodata` more difficult when working on file handlers or `AstroData` objects.

The previous (quick) solution to this was to log the exceptions. However, DRAGONS expects that logs are clean in instances where there are no issues with creating an `AstroData` object from a file/from data. The log level for that message was also too high (error).

This PR removes the logged messages, instead catching the errors and only returning failure information (if any exceptions were raised) if the data fails to match at all. This preserves the expected behavior 

## Notes

This only works if no registered `AstroData<Name>` class object successfully matches, or none of the file openers in `AstroDataFactory._file_openers` successfully open the file. E.g., it still will not report exceptions if any objects/file openers are "successful", even if unintentional or unexpected.

To remedy that while preserving previous behavior, messages are still logged at the "debug" level to aid in debugging problems with `AstroDataFactory`. 