### PR TITLE
[FIX] Un-deprecate add_header_to_table.

### DIFF
--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -289,21 +289,12 @@ def header_for_table(table):
     return fits_header
 
 
-@deprecated(
-    "The functionality of this function is now covered by the "
-    "astropy.io.fits.Header class."
-)
 def add_header_to_table(table):
     """Add a FITS header to a table's metadata. Deprecated.
 
     This does not modify the table itself, but adds the header to the table's
     metadata.  If a header is already present in the table's metadata, it will
     ensure it's up to date with the table's columns.
-
-    Warning
-    -------
-    This function is deprecated and will be removed in a future version. Its
-    functionality is covered by Tables.
 
     Arguments
     ---------


### PR DESCRIPTION
# Summary

This un-deprecates `add_header_to_table` as it is now used in DRAGONS. The need for this function was brought up during the pyOpenSci review, and looking back at that it seems like the concerns there are still addressed (now that there's a docstring, and it's not used elsewhere in astrodata).