### PR TITLE
[FIX] Un-deprecate header attr

### DIFF
--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -28,7 +28,6 @@ from .nddata import ADVarianceUncertainty, NDAstroData
 from .utils import (
     assign_only_single_slice,
     astro_data_descriptor,
-    deprecated,
     normalize_indices,
     returns_list,
 )
@@ -431,17 +430,8 @@ class AstroData:
         return headers[0] if self.is_single else FitsHeaderCollection(headers)
 
     @property
-    @deprecated(
-        "Access to headers through this property is deprecated and "
-        "will be removed in the future. Use '.hdr' instead."
-    )
     def header(self):
-        """Return the headers for the PHU and each extension.
-
-        .. warning::
-
-            This property is deprecated and will be removed in the future.
-        """
+        """Return the headers for the PHU and each extension."""
         return [self.phu] + [ndd.meta["header"] for ndd in self._nddata]
 
     @property

--- a/tests/unit/test_deprecated.py
+++ b/tests/unit/test_deprecated.py
@@ -49,11 +49,6 @@ def test_open(example_fits_file):
         astrodata.open(example_fits_file)
 
 
-def test_deprecated_astrodata_header(ad):
-    with pytest.warns(AstroDataDeprecationWarning):
-        ad.header
-
-
 def test_deprecated_astrodatafactory_openFile(example_fits_file):
     with pytest.warns(AstroDataDeprecationWarning):
         astrodata.factory._openFile(example_fits_file)

--- a/tests/unit/test_fits.py
+++ b/tests/unit/test_fits.py
@@ -754,18 +754,13 @@ def test_header_collection(GMOSN_SPECT):
 
 @skip_if_download_none
 @pytest.mark.dragons_remote_data
-def test_header_deprecated(GMOSN_SPECT):
+def test_header_attr(GMOSN_SPECT):
     ad = astrodata.from_file(GMOSN_SPECT)
-    with pytest.warns(AstroDataDeprecationWarning):
-        warnings.simplefilter("always", AstroDataDeprecationWarning)
-        header = ad.header
+
     assert header[0]["ORIGNAME"] == "N20170529S0168.fits"
     assert header[1]["EXTNAME"] == "SCI"
     assert header[1]["EXTVER"] == 1
 
-    with pytest.warns(AstroDataDeprecationWarning):
-        warnings.simplefilter("always", AstroDataDeprecationWarning)
-        header = ad[0].header
     assert header[0]["ORIGNAME"] == "N20170529S0168.fits"
 
 

--- a/tests/unit/test_fits.py
+++ b/tests/unit/test_fits.py
@@ -754,12 +754,16 @@ def test_header_collection(GMOSN_SPECT):
 
 @skip_if_download_none
 @pytest.mark.dragons_remote_data
-def test_header_attr(GMOSN_SPECT):
+def test_header(GMOSN_SPECT):
     ad = astrodata.from_file(GMOSN_SPECT)
+
+    header = ad.header
 
     assert header[0]["ORIGNAME"] == "N20170529S0168.fits"
     assert header[1]["EXTNAME"] == "SCI"
     assert header[1]["EXTVER"] == 1
+
+    header = ad.header
 
     assert header[0]["ORIGNAME"] == "N20170529S0168.fits"
 


### PR DESCRIPTION
# Summary

This un-deprecates the header attr for `AstroData` objects. Issue #92 now tracks the confusion on my part that led to initial deprecation.