### PR TITLE
Modification to pre-commit requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,14 @@ repos:
   hooks:
     # Run the linter.
     - id: ruff
-      args: [ --fix ]
+      # args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
+      args: [ --diff]
 
-- repo: https://github.com/compilerla/conventional-pre-commit
-  rev: v3.4.0
-  hooks:
-    - id: conventional-pre-commit
-      stages: [commit-msg]
-      args: []
+#- repo: https://github.com/compilerla/conventional-pre-commit
+#  rev: v3.4.0
+#  hooks:
+#    - id: conventional-pre-commit
+#      stages: [commit-msg]
+#      args: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ ignore = [
   "ANN",
   "B",
   "C",
+  "COM812",
   "DTZ003", # TODO: datetime issue -- Issue #17
   "EM",
   "FIX",  # TODO: Reinstate TODO statements -- Issue #44
@@ -213,6 +214,8 @@ ignore = [
   "S603",
 ]
 
+[tool.ruff.format]
+skip-magic-trailing-comma = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
turn off the commit formatting requirement and the automatic fixing for linting and formatting.  highlight the issues but do not fix them. that makes diff for relevant code changes hard to follow. keep linting in linting only commits. Also, turn off the ruff magic-trailing-comma formatting for short calls.