### PR TITLE
fix(dragons): Cast BZERO to final scaled data type, otherwise NumPy 2 refuses to add it for DQ, because it's 1 greater than the range of the signed int type stored in FITS. When both operands are explicit NumPy types, the intermediate result gets upcast as necessary, similar to the NumPy 1 behaviour.

### DIFF
--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -479,7 +479,9 @@ class FitsLazyLoadable:
         if bscale == 1 and bzero == 0:
             return data
 
-        return (bscale * data + bzero).astype(self.dtype)
+        return (bscale * data + np.array(bzero, dtype=self.dtype)).astype(
+            self.dtype
+        )
 
     def __getitem__(self, arr_slice):
         """Get a slice of the data."""


### PR DESCRIPTION
DRAGONS commit: James Turner - Jul 18, 2025 77abab00da7d606711133f83ab43edc52ed5b43f