### PR TITLE
fix(dragons): Don't inadvertently upcast VAR to float64 when zeroing negative vals with weak promotion enabled on NumPy 1 (corner case)

### DIFF
--- a/astrodata/nddata.py
+++ b/astrodata/nddata.py
@@ -36,7 +36,7 @@ class ADVarianceUncertainty(VarianceUncertainty):
                 "Negative variance values found. Setting to zero.",
                 RuntimeWarning,
             )
-            value = np.where(value >= 0.0, value, 0.0)
+            value = np.where(value >= 0.0, value, np.float32(0.0))
         VarianceUncertainty.array.fset(self, value)
 
 


### PR DESCRIPTION
DRAGONS commit: James Turner - Jul 22, 2025  5dd69e8a285a11806a5c8c9fa17ebc7a577f35a4