### PR TITLE
fix(dragons): windowedOp()[now windowed_operations()]: allow an already-created result object to be passed to avoid additional memory use

### DIFF
--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -1030,6 +1030,7 @@ def windowed_operation(
     dtype=None,
     with_uncertainty=False,
     with_mask=False,
+    result=None,
     **kwargs,
 ):
     """Apply function on a NDData objects by chunks.
@@ -1061,6 +1062,9 @@ def windowed_operation(
     with_mask : bool
         Compute mask?
 
+    result : NDData/None
+        if not None, the output will be written to this object
+
     **kwargs
         Additional args are passed to ``func``.
     """
@@ -1070,13 +1074,23 @@ def windowed_operation(
     if dtype is None:
         dtype = sequence[0].window[:1, :1].data.dtype
 
-    result = NDAstroData(
-        np.empty(shape, dtype=dtype),
-        variance=np.zeros(shape, dtype=dtype) if with_uncertainty else None,
-        mask=np.empty(shape, dtype=np.uint16) if with_mask else None,
-        meta=deepcopy(sequence[0].meta),
-        wcs=sequence[0].wcs,
-    )
+    if result is None:
+        result = NDAstroData(
+            np.empty(shape, dtype=dtype),
+            variance=np.zeros(shape, dtype=dtype) if with_uncertainty else None,
+            mask=np.empty(shape, dtype=np.uint16) if with_mask else None,
+            meta=deepcopy(sequence[0].meta),
+            wcs=sequence[0].wcs,
+        )  # fmt: skip
+    elif result.shape != shape:
+        raise ValueError(
+            "Object 'result' has a different shape than the inputs"
+        )
+    else:  # Don't update these things if they already exist
+        if result.meta is None:
+            result.meta = deepcopy(sequence[0].meta)
+        if result.wcs is None:
+            result.wcs = sequence[0].wcs
 
     # Delete other extensions because we don't know what to do with them
     result.meta["other"] = OrderedDict()

--- a/astrodata/nddata.py
+++ b/astrodata/nddata.py
@@ -688,10 +688,16 @@ class NDAstroData(AstroDataMixin, NDArithmeticMixin, NDSlicingMixin, NDData):
         """
         self.data[section] = input_data.data
 
-        if self.uncertainty is not None:
+        if (
+            self.uncertainty is not None
+            and getattr(input_data, "uncertainty", None) is not None
+        ):
             self.uncertainty.array[section] = input_data.uncertainty.array
 
-        if self.mask is not None:
+        if (
+            self.mask is not None
+            and getattr(input_data, "mask", None) is not None
+        ):
             self.mask[section] = input_data.mask
 
     def __repr__(self):

--- a/tests/unit/test_nddata.py
+++ b/tests/unit/test_nddata.py
@@ -60,6 +60,12 @@ def test_getattr(testnd):
     with pytest.raises(AttributeError):
         testnd.BAD_ATTR
 
+def _stack(arrays):
+    arrays = [x for x in arrays]
+    data = np.array([arr.data for arr in arrays]).sum(axis=0)
+    unc = np.array([arr.uncertainty.array for arr in arrays]).sum(axis=0)
+    mask = np.array([arr.mask for arr in arrays]).sum(axis=0)
+    return NDAstroData(data=data, variance=unc, mask=mask)
 
 def test_var(testnd):
     data = np.zeros(5)
@@ -80,15 +86,8 @@ def test_window(testnd):
 
 
 def test_windowedOp(testnd):
-    def stack(arrays):
-        arrays = [x for x in arrays]
-        data = np.array([arr.data for arr in arrays]).sum(axis=0)
-        unc = np.array([arr.uncertainty.array for arr in arrays]).sum(axis=0)
-        mask = np.array([arr.mask for arr in arrays]).sum(axis=0)
-        return NDAstroData(data=data, variance=unc, mask=mask)
-
     result = windowed_operation(
-        stack,
+        _stack,
         [testnd, testnd],
         kernel=(3, 3),
         with_uncertainty=True,
@@ -100,11 +99,33 @@ def test_windowedOp(testnd):
 
     nd2 = NDAstroData(data=np.zeros((4, 4)))
     with pytest.raises(ValueError, match=r"Can't calculate final shape.*"):
-        result = windowed_operation(stack, [testnd, nd2], kernel=(3, 3))
+        result = windowed_operation(_stack, [testnd, nd2], kernel=(3, 3))
 
     with pytest.raises(AssertionError, match=r"Incompatible shape.*"):
-        result = windowed_operation(stack, [testnd, testnd], kernel=[3], shape=(5, 5))
+        result = windowed_operation(_stack, [testnd, testnd], kernel=[3],
+                                    shape=(5, 5))
 
+def test_windowedOp_with_result(testnd):
+    result = NDAstroData(data=np.empty_like(testnd.data),
+                         variance=np.empty_like(testnd.data),
+                         mask=np.empty_like(testnd.data, dtype=np.uint16))
+    windowed_operation(_stack, [testnd, testnd],
+               kernel=(3, 3),
+               result=result,
+               with_uncertainty=True,
+               with_mask=True)
+
+    assert_array_equal(result.data, testnd.data * 2)
+    assert_array_equal(result.uncertainty.array, testnd.uncertainty.array * 2)
+    assert result.mask[3, 4] == 2
+
+    nd2 = NDAstroData(data=np.zeros((4, 4)))
+    with pytest.raises(ValueError, match=r"Can't calculate final shape.*"):
+        result = windowed_operation(_stack, [testnd, nd2], kernel=(3, 3))
+
+    with pytest.raises(AssertionError, match=r"Incompatible shape.*"):
+        result = windowed_operation(_stack, [testnd, testnd], kernel=[3],
+                                    shape=(5, 5))
 
 @pytest.mark.skip(
     "This is tested elsewhere, not explicitly. Not entirely "


### PR DESCRIPTION
DRAGONS commit: Chris Simpson Aug 13, 2025 8e153764129abb424953031b0826183c6541b672