### PR TITLE
remove python 3.10 from support.

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -34,7 +34,6 @@ jobs:
               uses: "actions/setup-python@v5"
               with:
                   python-version: |
-                    3.10
                     3.11
                     3.12
 
@@ -67,7 +66,6 @@ jobs:
 #              uses: "actions/setup-python@v5"
 #              with:
 #                  python-version: |
-#                    3.10
 #                    3.11
 #                    3.12
 #
@@ -107,7 +105,7 @@ jobs:
                     # TODO(teald): - macos-latest | Issue #39
 
                 python-version:
-                    - "3.10"
+                    - "3.12"
 
         steps:
             - uses: "actions/checkout@v4"

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -43,24 +43,24 @@ jobs:
                   if [[ "$RUNNER_OS" == "macOS" ]]; then
                     brew install gcc
                     echo "FC=gfortran" >> $GITHUB_ENV
-                    brew install openblas
+                    brew install openblas pkgconfig
                   else
                     echo "No action needed for Fortran compiler on $RUNNER_OS"
                   fi
 
-            - name: Build project with OpenBLAS paths
+            - name: Set OpenBLAS paths
               run: |
                 if [[ "$RUNNER_OS" == "macOS" ]]; then
-                  # Dynamically determine the Homebrew prefix (supports both Intel and Apple Silicon runners)
+                  # Dynamically determine the Homebrew prefix
                   BREW_PREFIX=$(brew --prefix openblas)
-                  
+
                   # Inject paths into the environment for compilers/linkers
-                  echo 'LDFLAGS="-L${BREW_PREFIX}/lib"' >> $GITHUB_ENV
-                  echo 'CPPFLAGS="-I${BREW_PREFIX}/include"' >> $GITHUB_ENV
-                  echo 'PKG_CONFIG_PATH="${BREW_PREFIX}/lib/pkgconfig"' >> $GITHUB_ENV
+                  echo "LDFLAGS=-L${BREW_PREFIX}/lib" >> $GITHUB_ENV
+                  echo "CPPFLAGS=-I${BREW_PREFIX}/include" >> $GITHUB_ENV
+                  echo "PKG_CONFIG_PATH=${BREW_PREFIX}/lib/pkgconfig" >> $GITHUB_ENV
 
                   # Also useful if your build relies on CMake
-                  echo 'OpenBLAS_DIR="${BREW_PREFIX}"' >> $GITHUB_ENV
+                  echo "OpenBLAS_DIR=${BREW_PREFIX}" >> $GITHUB_ENV
                 else
                   echo "No additional OpenBLAS build steps needed for $RUNNER_OS"
                 fi

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -53,7 +53,7 @@ jobs:
                 if [[ "$RUNNER_OS" == "macOS" ]]; then
                   # Dynamically determine the Homebrew prefix (supports both Intel and Apple Silicon runners)
                   BREW_PREFIX=$(brew --prefix openblas)
-                  
+
                   # Inject paths into the environment for compilers/linkers
                   echo 'LDFLAGS="-L${BREW_PREFIX}/lib"' >> $GITHUB_ENV
                   echo 'CPPFLAGS="-I${BREW_PREFIX}/include"' >> $GITHUB_ENV

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -35,7 +35,6 @@ jobs:
               uses: "actions/setup-python@v5"
               with:
                   python-version: |
-                    3.10
                     3.11
                     3.12
 
@@ -87,7 +86,6 @@ jobs:
 #              uses: "actions/setup-python@v5"
 #              with:
 #                  python-version: |
-#                    3.10
 #                    3.11
 #                    3.12
 #
@@ -139,7 +137,7 @@ jobs:
             - name: "Setup Python"
               uses: actions/setup-python@v5
               with:
-                  python-version: "3.10"
+                  python-version: "3.12"
 
             - uses: conda-incubator/setup-miniconda@v3
 

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -38,6 +38,12 @@ jobs:
                     3.11
                     3.12
 
+            -name: "Install Fortran Compiler"
+             run: |
+                 if [[ "$RUNNER_OS" == "macOS" ]]; then
+                     brew install gcc
+                     echo "FC=gfortran" >> $GITHUB_ENV
+
             - name: "Install dependencies"
               run: |
                   python -m pip install --upgrade pip

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -38,12 +38,14 @@ jobs:
                     3.11
                     3.12
 
-            -name: "Install Fortran Compiler"
-             run: |
-                 if [[ "$RUNNER_OS" == "macOS" ]]; then
-                     brew install gcc
-                     echo "FC=gfortran" >> $GITHUB_ENV
-                 fi
+            - name: "Install Fortran Compiler"
+              run: |
+                  if [[ "$RUNNER_OS" == "macOS" ]]; then
+                    brew install gcc
+                    echo "FC=gfortran" >> $GITHUB_ENV
+                  else
+                    echo "No action needed for Fortran compiler on $RUNNER_OS"
+                  fi
 
             - name: "Install dependencies"
               run: |

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -43,6 +43,7 @@ jobs:
                  if [[ "$RUNNER_OS" == "macOS" ]]; then
                      brew install gcc
                      echo "FC=gfortran" >> $GITHUB_ENV
+                 fi
 
             - name: "Install dependencies"
               run: |

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -38,14 +38,32 @@ jobs:
                     3.11
                     3.12
 
-            - name: "Install Fortran Compiler"
+            - name: "Install Fortran Compiler and OpenBLAS"
               run: |
                   if [[ "$RUNNER_OS" == "macOS" ]]; then
                     brew install gcc
                     echo "FC=gfortran" >> $GITHUB_ENV
+                    brew install openblas
                   else
                     echo "No action needed for Fortran compiler on $RUNNER_OS"
                   fi
+
+            - name: Build project with OpenBLAS paths
+              run: |
+                if [[ "$RUNNER_OS" == "macOS" ]]; then
+                  # Dynamically determine the Homebrew prefix (supports both Intel and Apple Silicon runners)
+                  BREW_PREFIX=$(brew --prefix openblas)
+                  
+                  # Inject paths into the environment for compilers/linkers
+                  echo 'LDFLAGS="-L${BREW_PREFIX}/lib"' >> $GITHUB_ENV
+                  echo 'CPPFLAGS="-I${BREW_PREFIX}/include"' >> $GITHUB_ENV
+                  echo 'PKG_CONFIG_PATH="${BREW_PREFIX}/lib/pkgconfig"' >> $GITHUB_ENV
+
+                  # Also useful if your build relies on CMake
+                  echo 'OpenBLAS_DIR="${BREW_PREFIX}"' >> $GITHUB_ENV
+                else
+                  echo "No additional OpenBLAS build steps needed for $RUNNER_OS"
+                fi
 
             - name: "Install dependencies"
               run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -804,10 +804,12 @@ def build_tests_unit(session: nox.Session) -> None:
         unit_test_build(session)
 
 
-@nox.session(venv_backend="conda",
-             venv_params=SessionVariables.dragons_venv_params,
-             python="3.12",
-             tags=["build_tests"])
+@nox.session(
+    venv_backend="conda",
+    venv_params=SessionVariables.dragons_venv_params,
+    python="3.12",
+    tags=["build_tests"],
+)
 @use_devpi_server
 def build_tests_integration(session):
     """Build tests using the devpi server.

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,21 +17,13 @@ import nox
 
 # Logic required because tomllib was introduced to the standard library in
 # python version 3.11.
-if sys.version_info[1] > 11:
+if sys.version_info[1] >= 11:
     import tomllib
 
-elif sys.version_info[0] < 3 or sys.version_info[1] < 10:
+elif sys.version_info[0] < 3 or sys.version_info[1] < 11:
     major, minor = sys.version_info[0], sys.version_info[1]
     py_version = f"{major}.{minor}"
-    raise Exception(f"Python version below 3.10 (using {py_version})")
-
-else:
-    # Only for python 3.10 support, which wont' be maintained much longer.
-    # To be removed when we drop support for python 3.10 (see: ISSUE #73)
-    from pip._vendor import tomli
-
-    tomllib = tomli
-
+    raise Exception(f"Python version below 3.11 (using {py_version})")
 
 # Nox configuration
 # Default nox sessions to run when executing "nox" without session
@@ -86,7 +78,6 @@ class SessionVariables:
 
     # Python versions
     python_versions: ClassVar[list[str]] = [
-        "3.10",
         "3.11",
         "3.12",
     ]  # fmt: skip
@@ -521,7 +512,7 @@ def dragons_release_tests(session: nox.Session) -> None:
     # Install the DRAGONS package, and ds9 for completeness.
     session.conda_install(
         "--quiet",
-        "dragons==4.0",
+        "dragons==4.2",
         "ds9",
         channel=SessionVariables.dragons_conda_channels,
     )
@@ -599,7 +590,7 @@ def dragons_dev_tests(session: nox.Session) -> None:
             session.log("DRAGONS repository already exists. Skipping clone.")
 
         with session.cd("dragons"):
-            session.run("git", "checkout", "v4.0.0", external=True)
+            session.run("git", "checkout", "master", external=True)
             # Install the DRAGONS package
             session.install("-e", ".", "numpy<2")
 
@@ -684,13 +675,19 @@ def integration_test_build(session: nox.Session) -> None:
     apply_data_caching_environment_variable(session)
     apply_macos_config(session)
 
-    # Fetch test dependencies from the poetry.lock file.
-    install_test_dependencies(session)
+    # We install the poetry dependency first, otherwise they will
+    # wipe clean the dragons conda dependencies.  Also install the
+    # core dependencies with conda to ensure that numpy and scipy
+    # match each other.  (one conda and one pip does not work)
+    install_test_dependencies(
+        session, poetry_groups=["main"], conda_install=True
+    )
+    install_test_dependencies(session, poetry_groups=["test"])
 
     # Install the DRAGONS package, and ds9 for completeness.
     session.conda_install(
         "--quiet",
-        "dragons==3.2",
+        "dragons==4.2",
         "ds9",
         channel=SessionVariables.dragons_conda_channels,
     )
@@ -807,7 +804,7 @@ def build_tests_unit(session: nox.Session) -> None:
         unit_test_build(session)
 
 
-@nox.session(venv_backend="conda", python="3.10", tags=["build_tests"])
+@nox.session(venv_backend="conda", python="3.12", tags=["build_tests"])
 @use_devpi_server
 def build_tests_integration(session):
     """Build tests using the devpi server.
@@ -1068,7 +1065,9 @@ def dragons_calibration(
     apply_macos_config(session)
 
     # We install the poetry dependency first, otherwise they will
-    # wipe clean the dragons conda dependencies.
+    # wipe clean the dragons conda dependencies. Also install the
+    # core dependencies with conda to ensure that numpy and scipy
+    # match each other.  (one conda and one pip does not work)
     install_test_dependencies(
         session, poetry_groups=["main"], conda_install=True
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -703,7 +703,7 @@ def integration_test_build(session: nox.Session) -> None:
     session.run("pytest", *SessionVariables.dragons_pytest_options, *pos_args)
 
 
-@nox.session
+@nox.session(python="3.12")
 def coverage(session: nox.Session) -> None:
     """Run the tests and generate a coverage report."""
     apply_data_caching_environment_variable(session)
@@ -804,7 +804,10 @@ def build_tests_unit(session: nox.Session) -> None:
         unit_test_build(session)
 
 
-@nox.session(venv_backend="conda", python="3.12", tags=["build_tests"])
+@nox.session(venv_backend="conda",
+             venv_params=SessionVariables.dragons_venv_params,
+             python="3.12",
+             tags=["build_tests"])
 @use_devpi_server
 def build_tests_integration(session):
     """Build tests using the devpi server.

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,7 +25,6 @@ files = [
 ]
 
 [package.dependencies]
-exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
@@ -139,39 +138,39 @@ tests = ["fsspec[http] (>=2022.8.2)", "lz4 (>=0.10)", "psutil", "pytest (>=8)", 
 
 [[package]]
 name = "asdf-astropy"
-version = "0.7.1"
+version = "0.11.0"
 description = "ASDF serialization support for astropy"
 optional = false
-python-versions = ">=3.10"
+python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "asdf_astropy-0.7.1-py3-none-any.whl", hash = "sha256:003b6969e066b3bae07027c724fe3e6434c49c3ba9d09f889bfecdc587086ba0"},
-    {file = "asdf_astropy-0.7.1.tar.gz", hash = "sha256:5aa5a448ee0945bd834a9ba8fb86cf43b39e85d24260e1339b734173ab6024c7"},
+    {file = "asdf_astropy-0.11.0-py3-none-any.whl", hash = "sha256:10ff554382bb10b1bc931159d2c91e4399487c27afc0051c90a062112e9f0b7f"},
+    {file = "asdf_astropy-0.11.0.tar.gz", hash = "sha256:6944700e3394a324a23772bdf97abb9803cd66a86b095101a548e9dfc650e2c0"},
 ]
 
 [package.dependencies]
-asdf = ">=2.14.4"
-asdf-coordinates-schemas = ">=0.3"
+asdf = ">=3.3.0"
+asdf-coordinates-schemas = ">=0.4"
 asdf-standard = ">=1.1.0"
-asdf-transform-schemas = ">=0.5"
-astropy = ">=5.2.0"
-numpy = ">=1.24"
+asdf-transform-schemas = ">=0.6"
+astropy = ">=6.0"
+numpy = ">=1.26.4"
 packaging = ">=19"
 
 [package.extras]
 docs = ["docutils", "graphviz", "matplotlib", "sphinx", "sphinx-asdf", "sphinx-astropy", "sphinx-automodapi", "tomli"]
-test = ["coverage", "pytest", "pytest-astropy", "scipy"]
+test = ["coverage", "gwcs (>=0.22)", "pytest", "pytest-asdf-plugin", "pytest-astropy", "scipy (>=1.14.1)"]
 
 [[package]]
 name = "asdf-coordinates-schemas"
-version = "0.3.0"
+version = "0.5.1"
 description = "ASDF schemas for coordinates"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "asdf_coordinates_schemas-0.3.0-py3-none-any.whl", hash = "sha256:9afe55443b9e6ab80c95fe57befef353ead0a95c5714904da29965c63ca81451"},
-    {file = "asdf_coordinates_schemas-0.3.0.tar.gz", hash = "sha256:c98b6015dcec87a158fcde7798583f0615d08125fa6e1e9de16c4eb03fcd604e"},
+    {file = "asdf_coordinates_schemas-0.5.1-py3-none-any.whl", hash = "sha256:6c80cf928fd2de7cbc7c1dd003809fca2678c90c8843586f5670f0cf99bb48a7"},
+    {file = "asdf_coordinates_schemas-0.5.1.tar.gz", hash = "sha256:d9cf72fc312f27cb8f2b9e6ce10c38ebf826e2e6b80ba1f591f75bb0eaf734e2"},
 ]
 
 [package.dependencies]
@@ -179,8 +178,8 @@ asdf = ">=2.12.1"
 asdf-standard = ">=1.1.0"
 
 [package.extras]
-docs = ["astropy (>=5.0.4)", "docutils", "graphviz", "matplotlib", "sphinx", "sphinx-asdf (>=0.1.3)", "sphinx-astropy", "sphinx-rtd-theme", "tomli"]
-test = ["asdf-astropy (>=0.2.0)", "pytest"]
+docs = ["astropy (>=5.0.4)", "docutils", "furo", "graphviz", "matplotlib", "sphinx", "sphinx-asdf (>=0.1.3)", "sphinx-astropy", "tomli"]
+test = ["asdf-astropy (>=0.2.0)", "pytest", "pytest-asdf-plugin"]
 
 [[package]]
 name = "asdf-standard"
@@ -200,42 +199,42 @@ test = ["asdf (>=3.0.0)", "packaging (>=16.0)", "pytest", "pyyaml"]
 
 [[package]]
 name = "asdf-transform-schemas"
-version = "0.5.0"
+version = "0.6.0"
 description = "ASDF schemas for transforms"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "asdf_transform_schemas-0.5.0-py3-none-any.whl", hash = "sha256:9f91bfd964b905d0deff269b057a75b2b3745c462c3b9e7897242844fbc4cfe8"},
-    {file = "asdf_transform_schemas-0.5.0.tar.gz", hash = "sha256:82cf4c782575734a895327f25ff583ce9499d7e2b836fe8880b2d7961c6b462b"},
+    {file = "asdf_transform_schemas-0.6.0-py3-none-any.whl", hash = "sha256:f63a5cc90c421209fd8e3b064c9cca8372220aa1c932676cad558942dc6153b0"},
+    {file = "asdf_transform_schemas-0.6.0.tar.gz", hash = "sha256:0f50f8e096fffd2d14b9c82995901266ef25b23d0dffc30ad41bba46851a9732"},
 ]
 
 [package.dependencies]
 asdf-standard = ">=1.1.0"
 
 [package.extras]
-docs = ["astropy (>=5.0.4)", "docutils", "graphviz", "matplotlib", "sphinx", "sphinx-asdf (>=0.1.3)", "sphinx-astropy", "sphinx-rtd-theme", "tomli"]
+docs = ["astropy (>=5.0.4)", "docutils", "furo", "graphviz", "matplotlib", "sphinx", "sphinx-asdf (>=0.1.3)", "sphinx-astropy", "tomli"]
 test = ["asdf (>=2.8.0)", "asdf-astropy", "pytest", "scipy"]
 
 [[package]]
 name = "asdf-wcs-schemas"
-version = "0.4.0"
+version = "0.5.0"
 description = "ASDF WCS schemas"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "asdf_wcs_schemas-0.4.0-py3-none-any.whl", hash = "sha256:ffd0dc9d01ff453c8e81793f93a76c4cdd7780b0156d39c93b8017df49180a01"},
-    {file = "asdf_wcs_schemas-0.4.0.tar.gz", hash = "sha256:c0bb44b8a5f16e2e23b028bcf4360729f5047a8d19063f1c8d817590d0b308b4"},
+    {file = "asdf_wcs_schemas-0.5.0-py3-none-any.whl", hash = "sha256:7050c7dfd252f2aa9c32e4fe3711c1823336d923f631816f8f3e9f27c95491f7"},
+    {file = "asdf_wcs_schemas-0.5.0.tar.gz", hash = "sha256:af7bdda46c20195b97272d8d3fdc7d9286beb143dbd69503f59c5ee1fe1559b5"},
 ]
 
 [package.dependencies]
-asdf-coordinates-schemas = ">=0.3.0"
+asdf-coordinates-schemas = ">=0.4.0"
 asdf-standard = ">=1.1.0"
-asdf-transform-schemas = ">=0.5.0"
+asdf-transform-schemas = ">=0.6.0"
 
 [package.extras]
-docs = ["astropy (>=5.0.4)", "docutils", "graphviz", "matplotlib", "sphinx", "sphinx-asdf (>=0.1.3)", "sphinx-astropy", "sphinx-rtd-theme", "tomli"]
+docs = ["astropy (>=5.0.4)", "docutils", "furo", "graphviz", "matplotlib", "sphinx", "sphinx-asdf (>=0.1.3)", "sphinx-astropy", "tomli"]
 test = ["asdf (>=2.8.0)", "asdf-astropy", "pytest (>=4.6.0)"]
 
 [[package]]
@@ -380,10 +379,8 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "os_name == \"nt\""}
-importlib-metadata = {version = ">=4.6", markers = "python_full_version < \"3.10.2\""}
 packaging = ">=19.1"
 pyproject_hooks = "*"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["furo (>=2023.8.17)", "sphinx (>=7.0,<8.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)", "sphinx-issues (>=3.0.0)"]
@@ -628,7 +625,6 @@ files = [
 [package.dependencies]
 build = ">=0.1"
 setuptools = "*"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [package.extras]
 test = ["mock (>=3.0.0) ; python_version == \"3.7\"", "pytest", "wheel"]
@@ -815,9 +811,6 @@ files = [
     {file = "coverage-7.8.0.tar.gz", hash = "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
@@ -870,7 +863,6 @@ iniconfig = "*"
 pkginfo = ">=1.10.0"
 platformdirs = "*"
 pluggy = ">=0.6.0,<2.0"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "devpi-common"
@@ -970,22 +962,6 @@ files = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-groups = ["build-test", "test"]
-markers = "python_version == \"3.10\""
-files = [
-    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
-    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
-
-[[package]]
 name = "filelock"
 version = "3.20.3"
 description = "A platform independent file lock."
@@ -999,27 +975,27 @@ files = [
 
 [[package]]
 name = "gwcs"
-version = "0.21.0"
+version = "0.26.1"
 description = "Generalized World Coordinate System"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "gwcs-0.21.0-py3-none-any.whl", hash = "sha256:5a89f512d2a9b2933534fa454b0f34361f714d896f53d9a4b9d1b3a2831b58cc"},
-    {file = "gwcs-0.21.0.tar.gz", hash = "sha256:8cd27f1ce6b25ad72cc33ca2e4178ab29d82050344c710713f74992136a1c5ba"},
+    {file = "gwcs-0.26.1-py3-none-any.whl", hash = "sha256:08829b42265f00669b1e2ea8112093235279b5026b9687b36d5f131f4e131ede"},
+    {file = "gwcs-0.26.1.tar.gz", hash = "sha256:17b443822ecc5bd6ef8be68b6ca279f44869b4a63bbd0761ece07d453f7f7d3e"},
 ]
 
 [package.dependencies]
-asdf = ">=2.8.1"
-asdf-astropy = ">=0.2.0"
-asdf-wcs-schemas = ">=0.4.0"
-astropy = ">=5.3"
-numpy = "*"
-scipy = "*"
+asdf = ">=3.3.0"
+asdf-astropy = ">=0.8.0"
+asdf_wcs_schemas = ">=0.5.0"
+astropy = ">=6.0"
+numpy = ">=1.25"
+scipy = ">=1.14.1"
 
 [package.extras]
-docs = ["sphinx", "sphinx-asdf", "sphinx-astropy", "sphinx-automodapi", "sphinx-rtd-theme", "stsci-rtd-theme", "tomli ; python_version < \"3.11\""]
-test = ["ci-watson (>=0.3.0)", "pytest (>=4.6.0)", "pytest-astropy"]
+docs = ["furo", "matplotlib", "sphinx", "sphinx-asdf", "sphinx-astropy", "sphinx-automodapi", "sphinx-copybutton", "sphinx-tabs"]
+test = ["ci-watson (>=0.3.0)", "pytest (>=8.0.0)", "pytest-astropy (>=0.11.0)"]
 
 [[package]]
 name = "h11"
@@ -1110,7 +1086,6 @@ files = [
 
 [package.dependencies]
 attrs = ">=22.2.0"
-exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
@@ -1179,12 +1154,12 @@ version = "8.6.1"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "build-test"]
+groups = ["main"]
+markers = "python_version == \"3.11\""
 files = [
     {file = "importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e"},
     {file = "importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580"},
 ]
-markers = {main = "python_version <= \"3.11\"", build-test = "python_full_version < \"3.10.2\""}
 
 [package.dependencies]
 zipp = ">=3.20"
@@ -1484,7 +1459,6 @@ files = [
 argcomplete = ">=1.9.4,<4"
 colorlog = ">=2.6.1,<7"
 packaging = ">=20.9"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 virtualenv = ">=20.14.1"
 
 [package.extras]
@@ -1858,12 +1832,10 @@ files = [
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
 iniconfig = ">=1.0.1"
 packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
@@ -2497,7 +2469,6 @@ sphinxcontrib-htmlhelp = ">=2.0.6"
 sphinxcontrib-jsmath = ">=1.0.1"
 sphinxcontrib-qthelp = ">=1.0.6"
 sphinxcontrib-serializinghtml = ">=1.1.9"
-tomli = {version = ">=2", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
@@ -2674,49 +2645,6 @@ files = [
 python-dateutil = ">=2.6.0"
 
 [[package]]
-name = "tomli"
-version = "2.2.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.8"
-groups = ["build-test", "docs", "test"]
-files = [
-    {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
-    {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8"},
-    {file = "tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff"},
-    {file = "tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b"},
-    {file = "tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"},
-    {file = "tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"},
-    {file = "tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98"},
-    {file = "tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4"},
-    {file = "tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"},
-    {file = "tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744"},
-    {file = "tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec"},
-    {file = "tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69"},
-    {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
-    {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
-]
-markers = {build-test = "python_version == \"3.10\"", docs = "python_version == \"3.10\"", test = "python_full_version <= \"3.11.0a6\""}
-
-[[package]]
 name = "tomlkit"
 version = "0.13.2"
 description = "Style preserving TOML library"
@@ -2749,12 +2677,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "build-test", "dev", "test"]
+groups = ["main", "build-test"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "python_version < \"3.13\"", dev = "python_version == \"3.10\"", test = "python_version == \"3.10\""}
+markers = {main = "python_version < \"3.13\""}
 
 [[package]]
 name = "urllib3"
@@ -2806,7 +2734,6 @@ files = [
 distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.20.1,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
-typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
@@ -2931,12 +2858,12 @@ version = "3.21.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "build-test"]
+groups = ["main"]
+markers = "python_version == \"3.11\""
 files = [
     {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
     {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
 ]
-markers = {main = "python_version <= \"3.11\"", build-test = "python_full_version < \"3.10.2\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
@@ -3022,5 +2949,5 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.10"
-content-hash = "7db91e44943b5b37e61df7ba601db35bbc8bb5e16703d78c3ff3b2deecbb4c75"
+python-versions = "^3.11"
+content-hash = "c2fc02a49128d20b6a0de18fb91618085def9b4c1e47af65b8054db67b670221"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 "Repository" = "https://github.com/GeminiDRSoftware/astrodata/"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 astropy = "^6.0.0"
 asdf = "^3.1.0"
-gwcs = "^0.21.0"
+gwcs = ">=0.25,<=1.0.0a0"
 jsonschema = "^4.21.1"
 numpy = "^1.26.4"
 requests = "^2.34.0"

--- a/tests/integration/dragons/test_gmos_imaging.py
+++ b/tests/integration/dragons/test_gmos_imaging.py
@@ -140,20 +140,21 @@ def test_gmos_imaging_tutorial_star_field(
     )
 
     # Initialize calibration service
-    if os.path.exists("calibration.db"):
-        os.remove("calibration.db")
-
-    caldb = cal_service.set_local_database()
-    caldb.init(wipe=True)
+    caldb = calibration_service
 
     for bpm in dataselect.select_data(all_files, ["BPM"]):
         caldb.add_cal(bpm)
 
     assert caldb.list_files()
 
+    # Passing the location of the dragonsrc directly to the Reduce
+    # instance because the DRAGONSRC environment variable does not seem
+    # to be picked up when reduce is run.  (Not a DRAGONS bug.)
+
     # Primary/"Master" bias
     reduce_bias = Reduce()
     reduce_bias.files.extend(biases)
+    reduce_bias.config_file = ".dragonsrc"
     reduce_bias.runr()
 
     bias_files = glob.glob("*bias*")
@@ -165,6 +166,7 @@ def test_gmos_imaging_tutorial_star_field(
     # Primary/"Master" flat
     reduce_flats = Reduce()
     reduce_flats.files.extend(flats)
+    reduce_flats.config_file = ".dragonsrc"
     reduce_flats.runr()
 
     flat_files = glob.glob("*flat*")
@@ -176,6 +178,7 @@ def test_gmos_imaging_tutorial_star_field(
     # Science images
     reduce_science = Reduce()
     reduce_science.files.extend(science)
+    reduce_science.config_file = ".dragonsrc"
     reduce_science.runr()
 
     science_files = glob.glob("*image*")

--- a/tests/integration/dragons/test_niri_imaging.py
+++ b/tests/integration/dragons/test_niri_imaging.py
@@ -123,11 +123,7 @@ def test_niri_imaging_tutorial_star_field(
     cal_service = importlib.import_module("recipe_system.cal_service")
 
     # Initialize calibration service
-    if os.path.exists("calibration.db"):
-        os.remove("calibration.db")
-
-    caldb = cal_service.LocalDB("./calibration.db")
-    caldb.init()
+    caldb = calibration_service
 
     # Use dataselect to sort data for reduction.
     all_files = sorted([str(path) for path in data.values()])
@@ -190,6 +186,7 @@ def test_niri_imaging_tutorial_star_field(
     # Darks
     reduce_darks = Reduce()
     reduce_darks.files.extend(darks_20_sec)
+    reduce_darks.config_file = ".dragonsrc"
     reduce_darks.runr()
 
     # Using glob to ignore the metadata stuff in case of changes.
@@ -206,6 +203,7 @@ def test_niri_imaging_tutorial_star_field(
         caldb.add_cal(bpm)
 
     reduce_bpm = Reduce()
+    reduce_bpm.config_file = ".dragonsrc"
     reduce_bpm.files.extend(flats)
     reduce_bpm.files.extend(darks_1_sec)
     reduce_bpm.recipename = "makeProcessedBPM"
@@ -220,6 +218,7 @@ def test_niri_imaging_tutorial_star_field(
 
     # Flats
     reduce_flats = Reduce()
+    reduce_flats.config_file = ".dragonsrc"
     reduce_flats.files.extend(flats)
     reduce_flats.uparms = [("addDQ:user_bpm", bpm)]
     reduce_flats.runr()
@@ -233,6 +232,7 @@ def test_niri_imaging_tutorial_star_field(
 
     # Standard star
     reduce_std = Reduce()
+    reduce_std.config_file = ".dragonsrc"
     reduce_std.files.extend(standard_stars)
     reduce_std.uparms = [("addDQ:user_bpm", bpm)]
     reduce_std.uparms.append(("darkCorrect:do_cal", "skip"))
@@ -246,6 +246,7 @@ def test_niri_imaging_tutorial_star_field(
 
     # Science
     reduce_target = Reduce()
+    reduce_target.config_file = ".dragonsrc"
     reduce_target.files.extend(science)
     reduce_target.uparms = [("addDQ:user_bpm", bpm)]
     reduce_target.uparms.append(("skyCorrect:scale_sky", False))

--- a/tests/unit/test_nddata.py
+++ b/tests/unit/test_nddata.py
@@ -196,11 +196,12 @@ def test_wcs_slicing():
     assert nd[:, ::-1].wcs(10, 10) == (39, 10)
 
     # Test when two identity models are used
+    inter_frame = Frame2D(name="inter_frame")
     i_gwcs = gWCS(
         [
             (in_frame, models.Identity(2)),
-            (out_frame, models.Identity(2)),
-            (in_frame, models.Identity(2)),
+            (inter_frame, models.Identity(2)),
+            (out_frame, None),
         ]
     )
 


### PR DESCRIPTION
The removal support for Python 3.10 led to the integration tests having to use DRAGONS v4.2 and latest from master branch.  Only DRAGONS v3.x supported Python 3.10.  As a result, the allowed version for gwcs had to be updated too.
The change to a newer Python required changes to the github workflow to install software to build scipy.