### PR TITLE
fix the missing conda channel when running sources_tests integration workflow

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -454,7 +454,12 @@ def install_test_dependencies(
                 if "semantic-version" not in line:
                     print(line, end="")
 
-        session.conda_install("--quiet", "--file", str(req_file_path))
+        session.conda_install(
+            "--quiet",
+            "--file",
+            str(req_file_path),
+            channel=SessionVariables.dragons_conda_channels,
+        )
 
 
 def apply_macos_config(session: nox.Session) -> None:


### PR DESCRIPTION
Dragons_release_tests works locally but fails in the github action because of missing channels.  Maybe the local run uses some of the local configurations.  The problem appears to be in the `session.conda_install` in the `install_test_dependencies` function. 