### PR TITLE
Bump actions versions in workflows and update assignee in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -4,7 +4,7 @@ title: "[Bug]: "
 labels: ["bug"]
 projects: []
 assignees:
-  - teald
+  - KathleenLabrie
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -4,7 +4,7 @@ title: "[DOCS]: "
 labels: ["documentation"]
 projects: []
 assignees:
-  - teald
+  - KathleenLabrie
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -4,7 +4,7 @@ title: "[Feat]: "
 labels: ["enhancement"]
 projects: []
 assignees:
-  - teald
+  - KathleenLabrie
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/other_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/other_issue.yaml
@@ -4,7 +4,7 @@ title: "[MISC]: "
 labels: ["misc"]
 projects: []
 assignees:
-  - teald
+  - KathleenLabrie
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -28,10 +28,10 @@ jobs:
 
         steps:
             - name: "Check out the repo"
-              uses: "actions/checkout@v4"
+              uses: "actions/checkout@v7"
 
             - name: "Set up Python"
-              uses: "actions/setup-python@v5"
+              uses: "actions/setup-python@v6"
               with:
                   python-version: |
                     3.11
@@ -60,10 +60,10 @@ jobs:
 #
 #        steps:
 #            - name: "Check out the repo"
-#              uses: "actions/checkout@v4"
+#              uses: "actions/checkout@v7"
 #
 #            - name: "Set up Python"
-#              uses: "actions/setup-python@v5"
+#              uses: "actions/setup-python@v6"
 #              with:
 #                  python-version: |
 #                    3.11
@@ -108,10 +108,10 @@ jobs:
                     - "3.12"
 
         steps:
-            - uses: "actions/checkout@v4"
+            - uses: "actions/checkout@v7"
 
             - name: "Set up Python"
-              uses: "actions/setup-python@v5"
+              uses: "actions/setup-python@v6"
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -121,7 +121,7 @@ jobs:
                   python -m pip install nox poetry
                   poetry self add poetry-plugin-export
 
-            - uses: conda-incubator/setup-miniconda@v3
+            - uses: conda-incubator/setup-miniconda@v4
               with:
                 python-version: "${{ matrix.python-version }}"
                 conda-remove-defaults: "true"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,8 +14,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
             python-version: 3.12
       - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
         run: |
           nox -s docs
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,13 +13,12 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v7
 
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v4
+            - uses: actions/setup-python@v6
 
             - name: Run image
-              uses: abatilo/actions-poetry@v2
+              uses: abatilo/actions-poetry@v3
 
             - name: Install linting (dev) dependencies
               run: poetry install --only=dev

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -27,10 +27,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/source_tests.yml
+++ b/.github/workflows/source_tests.yml
@@ -29,10 +29,10 @@ jobs:
 
         steps:
             - name: "Check out the repo"
-              uses: "actions/checkout@v4"
+              uses: "actions/checkout@v7"
 
             - name: "Set up Python"
-              uses: "actions/setup-python@v5"
+              uses: "actions/setup-python@v6"
               with:
                   python-version: |
                     3.11
@@ -89,7 +89,7 @@ jobs:
                   python -m nox -r -vv
 
             - name: "Upload coverage data"
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: covdata
                   path: .coverage.*
@@ -107,10 +107,10 @@ jobs:
 #
 #        steps:
 #            - name: "Check out the repo"
-#              uses: "actions/checkout@v4"
+#              uses: "actions/checkout@v7"
 #
 #            - name: "Set up Python"
-#              uses: "actions/setup-python@v5"
+#              uses: "actions/setup-python@v6"
 #              with:
 #                  python-version: |
 #                    3.11
@@ -140,7 +140,7 @@ jobs:
 #                  python -m nox -s script_tests --verbose -x -- -xvv
 #
 #            # - name: "Upload coverage data"
-#            #   uses: actions/upload-artifact@v4
+#            #   uses: actions/upload-artifact@v7
 #            #   with:
 #            #       name: covdata
 #            #       path: .coverage.*
@@ -158,15 +158,15 @@ jobs:
 
         steps:
             - name: "Check out the repo"
-              uses: "actions/checkout@v4"
+              uses: "actions/checkout@v7"
 
             # Setup python
             - name: "Setup Python"
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.12"
 
-            - uses: conda-incubator/setup-miniconda@v3
+            - uses: conda-incubator/setup-miniconda@v4
 
             - name: "Get public IP address of runner"
               # Need to handle this for MacOS and linux
@@ -204,7 +204,7 @@ jobs:
                 echo "immediately."
 
             - name: "Upload coverage data"
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: covdata
                   path: .coverage.*

--- a/.github/workflows/todo_to_issue.yml
+++ b/.github/workflows/todo_to_issue.yml
@@ -4,9 +4,9 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v7"
       - name: "TODO to Issue"
-        uses: "alstr/todo-to-issue-action@v4"
+        uses: "alstr/todo-to-issue-action@v5"
         with:
           AUTO_ASSIGN: true
           CLOSE_ISSUES: true


### PR DESCRIPTION
The default assignee is updated to myself as Teal is no longer working on the project.

The versions of various workflow actions needed to be bumped.  In particular, we should now be inline with the Node.js 24 requirement. 