### PR TITLE
Reinstate the tests on the python blocs found in the documentation

### DIFF
--- a/astrodata/testing.py
+++ b/astrodata/testing.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import unittest
 import urllib
 import warnings
@@ -1232,7 +1233,7 @@ def fake_fits_bytes(
             include_header_keys, dict
         ):
             for key in include_header_keys:
-                if key in include_header_values:
+                if include_header_values and key in include_header_values:
                     primary_hdu.header[key] = include_header_values[key]
                     continue
 
@@ -1306,6 +1307,77 @@ def fake_fits_bytes(
     file_data.seek(0)
 
     return file_data
+
+
+def create_test_file(
+    path: os.PathLike | None = None,
+    hdus: _HDUL_LIKE_TYPE | None = None,
+    n_extensions: int = 1,
+    image_shape: tuple[int, int] | None = None,
+    include_header_keys: Iterable[str] | None = None,
+    file_type: str = "fits",
+) -> str:
+    """Create a temporary file of a given type and return a path to the file.
+
+    Arguments
+    ---------
+    path : os.PathLike | None
+        The path to the file to be created. If None, a temporary file is
+        created.
+
+    hdus : HDUList | list[HDUBase] | None
+        The HDUList or list of HDUBase objects to be written to the file.  If
+        None, a file with a primary HDU and n_extension extension HDUs are
+        generated.
+
+    n_extensions : int
+        The number of extension HDUs to be created if hdus is None.
+        Default is 1 (primary HDU + single extension)
+
+    image_shape : tuple[int, int] | None
+        The shape of the image to be created in the primary HDU. If None, no
+        image is created.
+
+    include_header_keys : Iterable[str] | None
+        A list of header keywords to be included in the primary HDU. If None,
+        no header keywords are included.
+
+    file_type : str
+        The type of file to be created. Default is 'fits'.
+    """
+    if file_type.casefold() == "fits":
+        file_data = fake_fits_bytes(
+            hdus=hdus,
+            n_extensions=n_extensions,
+            image_shape=image_shape,
+            include_header_keys=include_header_keys,
+        )
+
+    else:
+        raise NotImplementedError(f"File type {file_type} not supported.")
+
+    if path is None:
+        temp_file, path = tempfile.mkstemp(suffix=f".{file_type}")
+
+    else:
+        if not path.endswith(f".{file_type}"):
+            directory = os.path.dirname(path)
+            file_name = os.path.basename(path).replace(".file_type", "")
+            temp_file, path = tempfile.mkstemp(
+                suffix=f".{file_type}", dir=directory, prefix=file_name
+            )
+
+        else:
+            temp_file, path = tempfile.mkstemp(suffix=f".{file_type}")
+
+    file = os.fdopen(temp_file, "w+b")
+
+    for chunk in iter(lambda: file_data.read(10000), b""):
+        file.write(chunk)
+
+    file.flush()
+
+    return path
 
 
 def test_script_file(

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,14 +14,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.14.1"
+version = "4.14.2"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
 groups = ["build-test"]
 files = [
-    {file = "anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72"},
-    {file = "anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"},
+    {file = "anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494"},
+    {file = "anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"},
 ]
 
 [package.dependencies]
@@ -273,14 +273,14 @@ typing = ["narwhals (>=1.42.0)", "pandas-stubs (>=2.0.2)", "scipy-stubs (>=1.14.
 
 [[package]]
 name = "astropy-iers-data"
-version = "0.2026.7.6.1.1.20"
+version = "0.2026.7.13.0.54.2"
 description = "IERS Earth Rotation and Leap Second tables for the astropy core package"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "astropy_iers_data-0.2026.7.6.1.1.20-py3-none-any.whl", hash = "sha256:7aa50fa7f6d13258357d1e17fa97f3a8c2f04b9a7429d056e986a91cc46576a0"},
-    {file = "astropy_iers_data-0.2026.7.6.1.1.20.tar.gz", hash = "sha256:bc38de235802c9f006c8a04693706e2adcc9e7ac1cbf415dc042b5f0ac14f1f3"},
+    {file = "astropy_iers_data-0.2026.7.13.0.54.2-py3-none-any.whl", hash = "sha256:0f0b22f43d0917d78382f35ef13acd72600752d65289a3f91e39ea67653264cd"},
+    {file = "astropy_iers_data-0.2026.7.13.0.54.2.tar.gz", hash = "sha256:d86e32e95e98a86f83b5b073627442924a0f45cf61a7828da4f565a17d726c2f"},
 ]
 
 [package.extras]
@@ -634,6 +634,69 @@ setuptools = "*"
 test = ["mock (>=3.0.0) ; python_version == \"3.7\"", "pytest", "wheel"]
 
 [[package]]
+name = "cmarkgfm"
+version = "2025.10.22"
+description = "Minimal bindings to GitHub's fork of cmark"
+optional = false
+python-versions = ">=3.9"
+groups = ["build-test"]
+files = [
+    {file = "cmarkgfm-2025.10.22-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37e0b126a3868e1497f8e10c11a49b007f6f4b3104032d3a51bb84404c0f4486"},
+    {file = "cmarkgfm-2025.10.22-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1214acf1ef779b129e13a1a51e446425feaed64fd11124f44f78c93021bba853"},
+    {file = "cmarkgfm-2025.10.22-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df2e8e1140e811d952c9eabc9471517f9193438e5eb17a9530f9559cbf216492"},
+    {file = "cmarkgfm-2025.10.22-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:30e8a48bc36e1e06e6938952e3d69e4c2a73cf2dcee1071942a7c036df1982ff"},
+    {file = "cmarkgfm-2025.10.22-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8d7ab8333f9cca9d4894d668ab06b19a97a30734d19c2e53ed83e33fe16d1891"},
+    {file = "cmarkgfm-2025.10.22-cp310-cp310-win32.whl", hash = "sha256:451da49653abcde96d4671824c37acc900f6d01f69687ebeb0bd59ebf99738e0"},
+    {file = "cmarkgfm-2025.10.22-cp310-cp310-win_amd64.whl", hash = "sha256:a815dab1d0f2e7af95613b26101143eb44dc92a3b44449096fa97ed54add822e"},
+    {file = "cmarkgfm-2025.10.22-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:18aba514abb3eedc04c3df7dd5a7743a92d7f313a04a3f7e17a059befce6fd5f"},
+    {file = "cmarkgfm-2025.10.22-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3da228e10238411fc6823e2d4db4d514ca41d93629a6f8be751325a5477288b9"},
+    {file = "cmarkgfm-2025.10.22-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:76e1cd82deb79d0d6c1a0a9822116c277c1f7c43496cd151c340999ac4721dec"},
+    {file = "cmarkgfm-2025.10.22-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:87fd3616505159090b031a9601b2a24ebb2ee999abc562d924b99711fc6bb498"},
+    {file = "cmarkgfm-2025.10.22-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f848d9698023ac9e352d73d92ab58119cb1268b12c3100578cf2d1ca1aeab2bf"},
+    {file = "cmarkgfm-2025.10.22-cp311-cp311-win32.whl", hash = "sha256:93f34a753939b034a478a36687c6fef9010023e2cbe451b0ec83205e34252419"},
+    {file = "cmarkgfm-2025.10.22-cp311-cp311-win_amd64.whl", hash = "sha256:43cb1e912675dd91fba97db47f8de7c19c0b3cf6456d188ff584c120bcaa12b9"},
+    {file = "cmarkgfm-2025.10.22-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:74a22cf245b32a918325a2895a9a3f6e737f0b10368b39e9a99d9e76fda4a78a"},
+    {file = "cmarkgfm-2025.10.22-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68368a18b90e2dd795182c6fc34cee3180b2c8b380cad50c7fbd5563abff01b1"},
+    {file = "cmarkgfm-2025.10.22-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:115fd0feaf93806b3a7c980615649b3c76a49c9dd89d5ea0c6240e10c6c71cee"},
+    {file = "cmarkgfm-2025.10.22-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:69ccb4afa039f5b81d35de95fe935405577e115f367dda534309d66a455db5cb"},
+    {file = "cmarkgfm-2025.10.22-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9bed95895226cba280a96543f49d46b469b9e42528b119f280f9852cd4fc7749"},
+    {file = "cmarkgfm-2025.10.22-cp312-cp312-win32.whl", hash = "sha256:fdf0a4689fb6febcbcaf675f2011a8074b100a4fc323f5754f627183ce492694"},
+    {file = "cmarkgfm-2025.10.22-cp312-cp312-win_amd64.whl", hash = "sha256:fc14ae28769b501f61a7364a1188c827dfcf839213f02d0159801bb71c8ae989"},
+    {file = "cmarkgfm-2025.10.22-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d8030955c836827b95f46f8fc520a58ab2a03fb23d4b56e2d976618099273298"},
+    {file = "cmarkgfm-2025.10.22-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:862b7f15ecf040fe9cd82f3be208286daddc5af94e1a20091af8451a0fe5fe74"},
+    {file = "cmarkgfm-2025.10.22-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:77840ddd24152881c2d374eae5e1baca462d24c2d78a937b6f30a12c2685cc0c"},
+    {file = "cmarkgfm-2025.10.22-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba7693b9a4c30b2ae2d07d10c4bd3fd01dfaaaaa67c93784923b792dd10bb037"},
+    {file = "cmarkgfm-2025.10.22-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:03435c2f57ed49be0e83b2743af5dced98c1287fb9ae41a12b8055cff984bf58"},
+    {file = "cmarkgfm-2025.10.22-cp313-cp313-win32.whl", hash = "sha256:aee2bf397cdf133025a2e66c6281e4fb6bd70420e3734b6dcf787ea9c2aadd78"},
+    {file = "cmarkgfm-2025.10.22-cp313-cp313-win_amd64.whl", hash = "sha256:f41b76d274c8886d0a440d6577cc0d73d0ea631c3bb07758adce74ba6911d790"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:974eb8a69d6835eeaf11cb8f7ed0ad4cb4ddda9223693ad02aeb56cb0c036afb"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a591b213ab226232dee0b6ac8873560f01bd8cf423310bd8ce3f1c7cf913fd1f"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54070905b888d0d4590e03f60c5153dd456f2297ff5ff9fc43ba6d561f2eff72"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:37eef93238957bb238669810e1e3fe835706f9cbb25362b5ae8bbd51e39af45f"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a6ee1d36735abaed7af1c8459bfabe664c3f5472bf65a390f52d5e12626304b9"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314-win32.whl", hash = "sha256:60e7745b429d5e3019380750b3cfaf10da4a5461ead3adf9c149251d8a6e1a3c"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314-win_amd64.whl", hash = "sha256:ee90cbccd9521aa51e8d619284bb7904c5b64387eef86cbad50717b8d943ce6d"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a8d39b0c2c1c58d81a1294ed99200cba1250ec217c079b36aff11ca6b2ca4881"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:481740a8ab020c4b8ee49746ea6ac45ec7b68b71740d12c696a64c30e26f6f49"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:367d1ab78f26af73b866a165358382c6e8e66d49da73621e832febeaeeb6400c"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2176dc0e5e4966ca4746dcbd26324adbe17be86f48756f28438d157ae1f26520"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c96d1238d91cf35e9c022af2e8c0be0a7ac227eb94497ffdf10584a684e38a3e"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314t-win32.whl", hash = "sha256:905a773bc866ccb4dc97a343057e2bfe07934522e1380831be413d3f93626f62"},
+    {file = "cmarkgfm-2025.10.22-cp314-cp314t-win_amd64.whl", hash = "sha256:f2a04d119d09f7f5c8b565b1e8c691596bfbc59d8cabac4d7fa542a069c2c70f"},
+    {file = "cmarkgfm-2025.10.22-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e42a5fd9869d7d4e7511df4262e8509b46453acc0fa4fcfc8e3acc74d99e85b"},
+    {file = "cmarkgfm-2025.10.22-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd70cef08a675b83dbce79a50af102cd9d2b40d8093c97d3d39e02b3365ca026"},
+    {file = "cmarkgfm-2025.10.22-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0651de7f1327cbaf29c6f257c29786c26a3f90a9506efb2a1fda70ab1cd99591"},
+    {file = "cmarkgfm-2025.10.22-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ec1184ef6c4aed1f526c37a52155f49bed2a65b59178cfee39556d01564c1643"},
+    {file = "cmarkgfm-2025.10.22-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:dc11bdc6b9024df35a7043ebef95b581705e08c764fc900b50da96641ffbab06"},
+    {file = "cmarkgfm-2025.10.22-cp39-cp39-win32.whl", hash = "sha256:05423a8cd8489302825fef3cdfacb6762101c07599e210ade523667d5a0ec87a"},
+    {file = "cmarkgfm-2025.10.22-cp39-cp39-win_amd64.whl", hash = "sha256:35f7008547e629aaec44c063c674f393f53ab6202b2ebfa8d3273a68b093e710"},
+    {file = "cmarkgfm-2025.10.22.tar.gz", hash = "sha256:5bec61007b65b919488442c838c58a6c8bf4741f5103c593b2ef180d39818eda"},
+]
+
+[package.dependencies]
+cffi = ">=2.0.0"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -665,215 +728,104 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 development = ["black", "flake8", "mypy", "pytest", "types-colorama"]
 
 [[package]]
-name = "comrak"
-version = "0.0.12"
-description = "Python bindings for the Comrak Rust library, a fast CommonMark/GFM parser"
-optional = false
-python-versions = ">=3.9"
-groups = ["build-test"]
-files = [
-    {file = "comrak-0.0.12-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03c84830f84544d7b115097b8a06975eb3259fabca83b1c5ec36f9a01ec96cfe"},
-    {file = "comrak-0.0.12-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec28ad8826621750107cd9da554c1f662497bd4d56db0cf6664e74881b66ba48"},
-    {file = "comrak-0.0.12-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5119735a8ac85a33962125bd9287fa6f936177a0a27d471f0ded3b845eade2af"},
-    {file = "comrak-0.0.12-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:68fb856a6ce513e187df90c5bd9cd0be47a637bcd18fa10e59d34053304cb76c"},
-    {file = "comrak-0.0.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d8497adef53e990173b213804b00dfa6f749ed4b86121caa1ed8ea19ed9969d"},
-    {file = "comrak-0.0.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:aa0a6a09ac42af32c5052a27b942091f6edfa13adf4dc47b510f8f5534d37f75"},
-    {file = "comrak-0.0.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b448578dca363a06e1885fa2ad721b11c02871448c28fcf5bfe3f804c8d29956"},
-    {file = "comrak-0.0.12-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:7968c8e235793842149da147596846bdfc5ee6bb4993df6b4882882110eab26b"},
-    {file = "comrak-0.0.12-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:20bddf2f85aaf827ada08488651d2a74f0d69b360f1b79559903cbd46e7328c2"},
-    {file = "comrak-0.0.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e9942242b318e665be7c45a52bd3f138f6fdb6183fa0dd4894d801700bb9acee"},
-    {file = "comrak-0.0.12-cp310-cp310-win_amd64.whl", hash = "sha256:7bb122e59367e64ea20e6ed93f18917aaf8231c5fb865fd5e706af7dceb4079a"},
-    {file = "comrak-0.0.12-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0cf97a37fab1b231d9268a3b2e05c2d2caf3afb546ea502f317a82dbdd1260bb"},
-    {file = "comrak-0.0.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af0ee030b52dd2b1f03707536c5ab8ffc5885e11c0e165477d91b2d131e8cbf1"},
-    {file = "comrak-0.0.12-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f93a39d677d58ae68588796d2a6919d8eb473e13e7cdf0897761eb8dd050766c"},
-    {file = "comrak-0.0.12-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:98b75688fec84ced15105d13f116bbf5449ade27a1247222d48caba34c314547"},
-    {file = "comrak-0.0.12-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f59c715872da4445dd78e4dc72591cbfadf01e98701b9be616b0c8ecda06eda8"},
-    {file = "comrak-0.0.12-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5688e22d04610e439cd158a11a26b4f42a8dfaef298c2a095c9e47cc287c645a"},
-    {file = "comrak-0.0.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42f5b0816b6b137c85593525dd31e28669e242033e59855a87e4cf268194dd42"},
-    {file = "comrak-0.0.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdbc83e7f0dae57a6da43f2e100f093abae7d4faf4d3628d17a9cc3a3d36cdce"},
-    {file = "comrak-0.0.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f53d982909c9554813dcfe5a8eb2adeb36c91052a881f5dfb9ea53c71dd89ad"},
-    {file = "comrak-0.0.12-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:2a3d339bb997d9401513a570372fea35662f051da19198c2daab6cb9fff4ad46"},
-    {file = "comrak-0.0.12-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d2cc74d07a1a79cda9ffe019954e564476a71edb89c631bdb61f33ab06a017e"},
-    {file = "comrak-0.0.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:04eb081cae82d0147d196e1b5e9f1cf3a8af95399f4bc9595bcbc7a65b8035b4"},
-    {file = "comrak-0.0.12-cp311-cp311-win_amd64.whl", hash = "sha256:711d359bf62bbd86fdcaa668b01dd7dd96748dbb2c492d278ea8a0d4cceae0c6"},
-    {file = "comrak-0.0.12-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:44d470c435d01f5570a9cea339b8f6320036d413b7c4a81c5675e4d2aa85d930"},
-    {file = "comrak-0.0.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff6d6388a07e0b24909f8713f29bd1b1d6f27fd300c6dac41c97a92a011d6f15"},
-    {file = "comrak-0.0.12-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a09ed68e59865b8e53f6e57f0fe07953e36683e1bcc4f043c1a3f973cf7087fb"},
-    {file = "comrak-0.0.12-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb713936cbbfaa1fa6188241f3ba2731b250b52599585b4b9f7959d33849eafc"},
-    {file = "comrak-0.0.12-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b32a5aacfb4c86e07c4a8e0b35d32f96ed40e3504b9293f0b5eb36a7ccc4724b"},
-    {file = "comrak-0.0.12-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e88ed73c617f8aa83917e238bce2303ffa62145db9511618e4ca4e3e211f62fc"},
-    {file = "comrak-0.0.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20861ec4e94b783ee08ee995c781ffd4102e26cd3c3487fe1a8612f73f0fd95f"},
-    {file = "comrak-0.0.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ac824e32fb3038b837deec1d3aa11ea848af9be43f22d13777c3dba30a91d5e8"},
-    {file = "comrak-0.0.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:238327f52c68500cb7a1e5d91d1814a0b32f014b757982fd00e8b0fcc0bc04ee"},
-    {file = "comrak-0.0.12-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:75741500f8bbd76ad4bcc5b5276e823af6c5eb79eba6eaf6538ea547208d6ca1"},
-    {file = "comrak-0.0.12-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:326422cec15657836811465afa356e6868936c13e143727db05d1fe9af2fc0ba"},
-    {file = "comrak-0.0.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58ae6362d5d669de1bfe2c7bbc9782d94ca4b7b79216c56d2294730da0bfaf7b"},
-    {file = "comrak-0.0.12-cp312-cp312-win_amd64.whl", hash = "sha256:55366c0e274d487b1b309b5a27ac250fdcb67462f93d96826289926e9f3c5c66"},
-    {file = "comrak-0.0.12-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a3474ff5c234ccbbd442588debcfd4aa9997fc5a11e211b3cbf88fa07bea9b51"},
-    {file = "comrak-0.0.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6d80a96a2b9a0e8e491c7b6fd1897a9046012d530c7a184185efbd2790a7d15b"},
-    {file = "comrak-0.0.12-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:400959dafa92a730290b670c2917039c8fc3d65165cd2c55db02d613b1619769"},
-    {file = "comrak-0.0.12-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8d6822ef487e173a2bb062c23f3a6e646b1c3022455d3fd308856c516c022df7"},
-    {file = "comrak-0.0.12-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba3003a4ac27efedadd513fd2b4cfd75d60b7a3cf7db579f68233645cc14550"},
-    {file = "comrak-0.0.12-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d7e23a097a16780b040f2b5bdc05473aee0ff914cab1a7df64cc469d84803ce"},
-    {file = "comrak-0.0.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f80cbe4b856d36cf020b865346480c8efb9adf18946cf3ffcc034cef77c2617"},
-    {file = "comrak-0.0.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:998ed68b30003fceb7e245c6a37eb3ae1c2b952737b62b188177b28a72198157"},
-    {file = "comrak-0.0.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e9105d47e26e24dc484651175ce9b2c56d89bacfdab4d1ae0634112e1d2d225"},
-    {file = "comrak-0.0.12-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:991a677fd0f921a8a5471f9ac7258438c390cc63f11870fda97ba9e9e3729220"},
-    {file = "comrak-0.0.12-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:13e7fd5c11b4e837654e6f07148368d18113694c15898ab5c13a40876d39bdef"},
-    {file = "comrak-0.0.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:56ffa532b46de68d0296bc4596c92bc42711002cd8085392ed564131e9d781dd"},
-    {file = "comrak-0.0.12-cp313-cp313-win_amd64.whl", hash = "sha256:6bf34e4880a46f75636468d04b58a6723c967d909bef5d1c5e0ae0c7ac79e8fe"},
-    {file = "comrak-0.0.12-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca4e15d2244e6daa53dab93ef7e9b8d7d4cde6812db66b192fe34f4b8381c868"},
-    {file = "comrak-0.0.12-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4424df6c7603157a6e44cf5135390462f973fbffd3909039401ddb3ef195c3e1"},
-    {file = "comrak-0.0.12-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8478f2aff7c3493e6ec1f9cd55444a8e22ff2cc7ca9a6ae4dfec4856bf090211"},
-    {file = "comrak-0.0.12-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:492fe74bfb7462f112b9cbae72a4c8ab21bf3270dc3d494101fec51c5060f0da"},
-    {file = "comrak-0.0.12-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:673242619160d8aad8e4022f5467281b02eefecec5dd3122a983c36570c5c611"},
-    {file = "comrak-0.0.12-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:5f3952172f2768e00ca0a4585c64c18cfe1aa4e717a23fd60f809ff2637ab6fb"},
-    {file = "comrak-0.0.12-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:08352adca9ca4cf97ed2464cbb24958b21d8a8fcf44de7f9531652c758ed2e85"},
-    {file = "comrak-0.0.12-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:14fe339bab341cfeb1e8923175973d03f21c402d7d919dfc0fa270aaad35a726"},
-    {file = "comrak-0.0.12-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:db2548981a5e95af88d994d444e8aa2647e54c80c2e96053215fcab1f3149bab"},
-    {file = "comrak-0.0.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6db500bb6aced3d8e1128de828625759b41200398895f3812ebc460579670b24"},
-    {file = "comrak-0.0.12-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:980441b17d931bf3cae2ed52588a4a28502c310413f95d0867ebeaf72ac7e945"},
-    {file = "comrak-0.0.12-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:19fae86ffe755fda0237cecd40e96cb256036641fe10727e6d2148db20cf03fd"},
-    {file = "comrak-0.0.12-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd3b094a33dc117f47e4043e5fd20d6f9aeccedd3ee1d22013b046719b6a7f9d"},
-    {file = "comrak-0.0.12-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:68a90538a01bd776f6b34d9f48193662d3c61bccf3f30418942511ece294ec7b"},
-    {file = "comrak-0.0.12-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01a05b62ddaa3b1756de4eb992a137cd11191e8dc75611c87064db6d6c944430"},
-    {file = "comrak-0.0.12-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d4d58bee0f93599078a8d1bd5c3cf85cec267520d2cd095916d6155249e41d42"},
-    {file = "comrak-0.0.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:95281c45bd81b9e1388abb0338f890d4bf70b0faa7e5ce07b96d7e3edd07fa50"},
-    {file = "comrak-0.0.12-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:3b4947eb3bd6e468cc2505cd8b9d4eaf62644a3c234cdb3203cfdb4f2568f178"},
-    {file = "comrak-0.0.12-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1c4df51394b27d0816b517e68110ec9780a2be3c373215619c71f29f81e379e5"},
-    {file = "comrak-0.0.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:07d07c5b44a0e251c1638a15e0b46bb3d45b38cf35584aa39f5718785db417ca"},
-    {file = "comrak-0.0.12-cp314-cp314-win32.whl", hash = "sha256:565fa228f2fe6631d7c8d545133719d0503c9744c21770dc64afaff3874500b4"},
-    {file = "comrak-0.0.12-cp314-cp314-win_amd64.whl", hash = "sha256:4bbd7891df0ed8a9da825c88ea5dc9fb549fd35fff541147f8215fce35b7acb6"},
-    {file = "comrak-0.0.12-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1daf8b9673210187f80fd4d63f5154cc040991f87932dfb0c1f9d56e1a45e33"},
-    {file = "comrak-0.0.12-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c95f109dd89b4d449fc5d482d8d7b1cbe2604516743473d79cf838e76b03ff23"},
-    {file = "comrak-0.0.12-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:206c31a606baf9477509cd12de2acf927e88ffd132d5cfd8e0b30ca21fdd17de"},
-    {file = "comrak-0.0.12-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c2168a1e34e738b67af93de36d895ecdbd0dd88f24f4faefaefab7f606726f54"},
-    {file = "comrak-0.0.12-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:14a154fa9af26138380a7314dce856f20e77718596cc08fc0e3ec119489b1654"},
-    {file = "comrak-0.0.12-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:83e365188877efdeadbdf0e867be1070200fa2241ce96fd8afa18d929880110d"},
-    {file = "comrak-0.0.12-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8d12825eeda93d34c4085cf0290b8750858ad194bae58f306c2bd2556a288891"},
-    {file = "comrak-0.0.12-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:13bfaf90921b75b95bbb542f9895098d94fad5ad3e02d101274f8d539aff257d"},
-    {file = "comrak-0.0.12-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8286b98cbae1fc08dd7f70d15ef872d6cae69375a81ef05046f02d4e1cfc402"},
-    {file = "comrak-0.0.12-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:69e4cd727ab9ef30d1bc18115a55c34810d4a1b89eb069a70240feadbd278078"},
-    {file = "comrak-0.0.12-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7557ea26c6d90036b746970df5ee181aa2f61e3270b97eee105d9320a6f0592b"},
-    {file = "comrak-0.0.12-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a298f168ac74b15b7547dfc3e4169699595d1e75ec96978383bb3415493d435c"},
-    {file = "comrak-0.0.12-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7c1a74416b3026bc0911618b2bbde5a8908e6a607d049e7d15de55de8d607e0"},
-    {file = "comrak-0.0.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1b9992a49ee64881633e1b360a20468555561785bcafe9b1246e129b3383981c"},
-    {file = "comrak-0.0.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f56fae0945adcfe84b2aaf7e15c30c0d8b1d1a74c645b4cd35c221eb351e8c58"},
-    {file = "comrak-0.0.12-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:46b0fd5e417c1e4174f6506d237538f76367debc5c74c77f386c01b6e668bf80"},
-    {file = "comrak-0.0.12-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3a67968cba709d26bee39563bda874a6a1654a2851f4234b0701068cf3059ac4"},
-    {file = "comrak-0.0.12-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:76fa69d36d3c68b7edd4d9dd62f3ab187cb5df37ff05579fde729ace1ac267b8"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e286b8e93e6be4e18d3c5da2ca6cdcee2571daf99edc19db807289ccbe448d0"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71726f29c15709de2ed180e830e7d9d7ccc12fa12a6542ef5c1ba6d109514683"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d3b8deac388bf217a8748cfa7c781c4c4d59dad1fc29099a1355890a5a93e5a"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d693559a647561413874e04d7738ca9ac16a8a595264837690355df85b734742"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a629af213da7a99ccf7bde37937d122e008c2af7190f0f21cbe1c8952ecb4da"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8f25f3cd09957888880de182ffdc7329b5fed03d59849f3320f07e7b0081e452"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:83fef04a4408d1a06aa12c2c4ceb001888e86dec6c0728503d5609eddf14cd5d"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:3cf53fecdb3517b00c0948299a76311ea226eae279b9ad98765b8327671e6f89"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1612e75d15cb4c780af85791bd783fb3564b429812ceb2f02c3ed8537ef37c23"},
-    {file = "comrak-0.0.12-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5bb793ed27e7043642720c5d75fc6f75456440a78a89be3ffc1fbc6420c6d12f"},
-    {file = "comrak-0.0.12.tar.gz", hash = "sha256:c75151aef4a1d7ed8f806b2827d7031272c0753ecd7bf64285388d66150bfcb7"},
-]
-
-[[package]]
 name = "coverage"
-version = "7.15.0"
+version = "7.15.1"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev", "test"]
 files = [
-    {file = "coverage-7.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:50913d4bf5ddafa6ca3693da5e4dd833dd1b772e0283c99ca7f7d287db67331a"},
-    {file = "coverage-7.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:359e141ccd33893ce3f1ad5525f8b96083003677c82182e5907d62d4ea5799fc"},
-    {file = "coverage-7.15.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3200b6204935f928c64b2ca1f923ab8c1acb7c9de45ec61569711b34d25cccaf"},
-    {file = "coverage-7.15.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:be616bf61346883b2cfdc5178669647e03531d81ab761a7e378558b7e8bcb628"},
-    {file = "coverage-7.15.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc7bafc3fe1059463a8fdd97ca79972d6e2bf819d775c7d54991b5b1971201d6"},
-    {file = "coverage-7.15.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b713aa7fcf325a01d4184d848acb46fd84f78fdb0978470c636b23a06a753d91"},
-    {file = "coverage-7.15.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e38e6fba2d56652fdfaf0231f8f78aeb805234a912de25dc291ee5cce5b8faa4"},
-    {file = "coverage-7.15.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:884499f42e382675be80770391983b90e0c0c774d87dbeeebf5f991cf6612b20"},
-    {file = "coverage-7.15.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:840481b12e083dbcbafab14794a8781a958edf327c8d3d70b4eee42f9b8253aa"},
-    {file = "coverage-7.15.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:276646e9481703d09f854f3b2f018f24e19fd7049ae670a92570043eb97203b1"},
-    {file = "coverage-7.15.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4de4b4d3f5545aa6c60dc4efd9c63b5b5dcc3bf00fe83146b2bdfffb8f6613bd"},
-    {file = "coverage-7.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5c504097b2a89b1e85bc6070d920df77daec701337e3aeef2c17775a5dd0ca90"},
-    {file = "coverage-7.15.0-cp310-cp310-win32.whl", hash = "sha256:f6e80ed91f98316e86b9c137206b04b2bcfbffccbdff49bd2eb09dddb1cf14e0"},
-    {file = "coverage-7.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:b3b3e22030f3f6f5e01a5ce69936552a5c0f6992b7698777377b99041961031f"},
-    {file = "coverage-7.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:003fff99412ea848c0aaebcc78ed2b6ce7d8a1227ed17e68470672770b78a02a"},
-    {file = "coverage-7.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5cbd804bf2784ce7b45114516050f346ecd50f960c4bb630a7ee9e1d78fa2118"},
-    {file = "coverage-7.15.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8773e15c23305b58882a4611fb9b2755977eae0dc2e515366a1b6c98866cc4c2"},
-    {file = "coverage-7.15.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f50e40081494c1dc4239ebb202014cbcc3306ea96fb6302a34c8cc0967fc5ae8"},
-    {file = "coverage-7.15.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daf96f37f5fc3a7b6c6da862eb4aee61c426bd63da236ed4a73ef0e503b4bca5"},
-    {file = "coverage-7.15.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:51aa20f6ae2788fd197747766edf4cd8234fd9423309b934257fa6b21a592723"},
-    {file = "coverage-7.15.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03d1f922757662eb7af586e77834792274cff776bc7b1d1a0b66a49ea9d84735"},
-    {file = "coverage-7.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a6d6acc9a7666245e6133dd15144ca038a85a9cd5026bb06d6bbae9e77440dc9"},
-    {file = "coverage-7.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1ac2c4c27c7df851dc9a017c2d7de00b69147e84ba3d96f37a530b0b6fb51035"},
-    {file = "coverage-7.15.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b761a1d504fd4bd1f20f418753964dca9f5862a511fc854dac58296b3b223671"},
-    {file = "coverage-7.15.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e43b045e11c16e897895758ae90e4a90cf99e93d58549e2f90c0e2272e155695"},
-    {file = "coverage-7.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:589b54513e901739f4b4582c705ce96b80c96f57641b1464607e2367a270e540"},
-    {file = "coverage-7.15.0-cp311-cp311-win32.whl", hash = "sha256:106781b8482749162d0b47056937ba0933508e5d9447f65a5e7d5c422f0d6bb4"},
-    {file = "coverage-7.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:821e92b3631d762a339695824cadbbc73020354eba2a23a551a99ad34938fbe6"},
-    {file = "coverage-7.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:309990eb5fb8014b9f67cb211f7fd41876ec8a88a88d3ae76de0ed1d611e3640"},
-    {file = "coverage-7.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b75ee5e8cb7575636ac598719b4307ac529ec8fcd79608a35c3cd4d4dada812d"},
-    {file = "coverage-7.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffb31267816b93b075302248cc1737506081b4f163df4401e9df1a6424aafabe"},
-    {file = "coverage-7.15.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4d0bb73455bf97ab243a8f12c37c686ccf1c13bb614b7b85f1d062f06f42b2c"},
-    {file = "coverage-7.15.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:20d9ccc4ebd0edc434d86dfd2a1dd2a8efa6b6b3073d0485a394fee86459ebb4"},
-    {file = "coverage-7.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20c8a976c365c8cb12f0cbd099508772ea41fb5fa80657a8506df0e11bd278c5"},
-    {file = "coverage-7.15.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f948fd5ba1b9cbca91f0ae08b4c1ce2b139509149a435e2585d056d57d70bf01"},
-    {file = "coverage-7.15.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f58185f06edf6ad68ec9fb155d63ef650c82f3fbd7e1770e2867751fb13158f4"},
-    {file = "coverage-7.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:02adc79a920c73c647c5d117f55747df7f2de94571884758ce8bc58e04f0a796"},
-    {file = "coverage-7.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6eb7c300fbed667fd6e3588eba71c1904cdb06110ca6fdf908c26bdd88b8e382"},
-    {file = "coverage-7.15.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b5fb23fa2de9dce1f5c36c09066d8fcda16cd96e8e26686caa2d7cb9b567d65c"},
-    {file = "coverage-7.15.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cec79341dbe6281484024979976d0c7f22beae08b4a254655decd25d42cbe766"},
-    {file = "coverage-7.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c664c5444b1d970b1b2a450e21fb19ee5c9cfdf151ded2dda37260031cca0da"},
-    {file = "coverage-7.15.0-cp312-cp312-win32.whl", hash = "sha256:5f764a3fa339bde6b3aa97657f5a6a3a9451e4a5b4ea98a2892c773a43525f77"},
-    {file = "coverage-7.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:52f9a4d2c4c56c8848bc2f524916698354b0211488b38c49ad9ae54f6cafbff6"},
-    {file = "coverage-7.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:31e5c3e70c85307ea35a12964e2e40f56ca2ee4b1c8c721ccf4609d17071080b"},
-    {file = "coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5be4caf3b28836f078abe700f8944dac4a65d78f16d6c600c89cb624e5535782"},
-    {file = "coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd58ad1404704303ca8d4f4b8a1095e7cbc7040ef17a66df1e6619aa10176430"},
-    {file = "coverage-7.15.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bbcbb317c2e5ded5b21104af81c29f391be2af98d065693ffbe8d23949b948e5"},
-    {file = "coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:27f31ecb458da3f859aab3f15ada871eb7a7768807d88df4a9f186bb17737970"},
-    {file = "coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fb759be317fdc62e0f56bffdf61cfcb45c7761ad6b71e3e583e71a67ae753c"},
-    {file = "coverage-7.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5cf007add5ab4bb8fa9f4c77e3732127c9e6cad501d7db43355fbfafca0be84"},
-    {file = "coverage-7.15.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc78d9843bd576fbe2118248258d485e968dc535f95ed504a7b0867ba9b51389"},
-    {file = "coverage-7.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a263060f1de0b4b74b4e089c2a70b8003b3781c733329a9c8fd54995328f9950"},
-    {file = "coverage-7.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c48decf16e0dfd5b049c7d5e82200c23c08126719142998d4f172444e3d0529e"},
-    {file = "coverage-7.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:08fb028000ed0aaa0a4cbdfbb98be7cb42f370db973fbbb469733505ab20e13e"},
-    {file = "coverage-7.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb7dc0c3b7d8a1077abea0b8546ebc5e26d6ef6ecefc2f0f5ad2b8a53bdad837"},
-    {file = "coverage-7.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cb3602054ccbe9f0d8c2dc04bbeba90d5719236e2cd06e042ddd6d3fc7b6e37"},
-    {file = "coverage-7.15.0-cp313-cp313-win32.whl", hash = "sha256:0bf781da64326b677be344df505171435b6f58716108606621d5d27d964fff8b"},
-    {file = "coverage-7.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:2c57a275078ee3fa185f83e400f765bc764a549de66d99b47881645cbd4ea629"},
-    {file = "coverage-7.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3812c61afc6685c7999b39320779ab8f43b7a3081fdb0def39976e56fbdb9a21"},
-    {file = "coverage-7.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:41cb79af843222e11da87127ad0ecbfa878abadd0f770a4a99391a27d3887324"},
-    {file = "coverage-7.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7d2008989ef8fe54188d3f3bfa2e3099b025af11e90a6a1b9e7dc433d04263d8"},
-    {file = "coverage-7.15.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:769e8ece11a596315ebf5aa7ec383aeeed016c091d2bf6363ffb996d41529092"},
-    {file = "coverage-7.15.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:65a6b6164ee5c39e2f3803f314292d6c61a607ba7fee253d1e03c42dc3903502"},
-    {file = "coverage-7.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75128817f95a5c45bb01d65fd2d8b9cb54bbe03d81608fb70e3e14b437ad56c2"},
-    {file = "coverage-7.15.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9887bb428fe2d4cd4bee89bac1a6c9932f484afd5b36fbd4ff6ea5f825bb1f5e"},
-    {file = "coverage-7.15.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0bfc0be1f702042207a93a00523b1065ee1fe951e96edf311581c0bbc2e34888"},
-    {file = "coverage-7.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f64627d55def5a43282d70e08396672692f77e4da610a5bb8bb4060b432b6859"},
-    {file = "coverage-7.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2c6f0fa473003905c6d5bac328ee4eba9fbea654f15bc24b8a3274b23363fa99"},
-    {file = "coverage-7.15.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2bcf9afaf064172c6ec3c58a325a9957ad1178c05dd934e25f253321776e0676"},
-    {file = "coverage-7.15.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:baf06bc987115d6fb938d403f7eab684a057766c490367999a2b71a6883110c6"},
-    {file = "coverage-7.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0405f2ff97b1c4c0e782cb32e02f32369bcf2e6b618b591d67e1ea754575dfe"},
-    {file = "coverage-7.15.0-cp314-cp314-win32.whl", hash = "sha256:ab282853ed5fbd64bbb162f19cb8fcb7087187508a6374b4f9c34ec1577c4e8f"},
-    {file = "coverage-7.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bb3040e9f4bbe26fcb0cd7cc85ac63e630d3f3a9c74f027abf4caa27e706663"},
-    {file = "coverage-7.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:346771144d34f7fa84ec28386f78e0f31653f33cf35e19d253d5b35f9e8201da"},
-    {file = "coverage-7.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d34a010905fb6401324ba016b5da03d574967f7b21ce48ea41e66f0f1f95f641"},
-    {file = "coverage-7.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bb25d825d885ca8036795dacfc3924d33091fc76d71ebc99420c6b79e77d96fa"},
-    {file = "coverage-7.15.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:94c9686bfe8a9a6810297aecbd99beaa3445f9e8dc2f80b1382cca0d86b64461"},
-    {file = "coverage-7.15.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9bd671c25f9d85f09d7ec481d0e43d5139f486c06a37139847a7ce569788af72"},
-    {file = "coverage-7.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:110cbdf8d2e216577312cf06ccf85539c0e5a5420ef747e4a4719b5e483c88cd"},
-    {file = "coverage-7.15.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2c5d4619214f1d9993e7b00a8600d14614b7e9d84e89507460b126aa5e6559e5"},
-    {file = "coverage-7.15.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:781a704516e2d8346fbbd5be6c6f3412dd824785146528b3a01816f26c081007"},
-    {file = "coverage-7.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd4a1b44bcb65ee29e947ac92bbee04956df3a6bfc6143641bb6cae7ede00fc9"},
-    {file = "coverage-7.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0e4950c9d6d3e39c64c991814ff315e2d0b9cb8152363594212c9e55208c0a8f"},
-    {file = "coverage-7.15.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:fe9c87ff42e5472d80d21704972e1f96e104a0a599d77c5e35db5a3c562e2571"},
-    {file = "coverage-7.15.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f00d5ae1dd2fe13fb8186e3e7d37bcbd8b25c0d764ff7d1b32cef9be058510a8"},
-    {file = "coverage-7.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:363ab38cc78b615f11c9cac3cf1d7eef950c18b9fdedfb9066f59461dcf84d68"},
-    {file = "coverage-7.15.0-cp314-cp314t-win32.whl", hash = "sha256:54fd9c53a5fafff509195f1b6a3f9be615d8e8362a3629ff1de23d270c03c86b"},
-    {file = "coverage-7.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:87b47553097ba185ed964866078e7e63adea9f5f51b5f39691c34f30afd21080"},
-    {file = "coverage-7.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aeefb2dd178fe7eee79f0ad25d75855cb35ee9ed472db2c5ea06f5b4fd00cec5"},
-    {file = "coverage-7.15.0-py3-none-any.whl", hash = "sha256:56da6a4cbe8f7e9e80bd072ca9cefe67d7106a440a7ec06519ec6507ac94ad19"},
-    {file = "coverage-7.15.0.tar.gz", hash = "sha256:9ac3fe7a1435986463eaa8ee253ae2f2a268709ba4ae5c7dd1f52a05391ad78f"},
+    {file = "coverage-7.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:05d87c2a43373ad6b976d0a99ad58c48633633bcdeb896dc645a006472cc4a71"},
+    {file = "coverage-7.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2afce82f2cf8f4c9002746a42755e1dc61baff33d9f7ab5569b4c9101f8f4d1d"},
+    {file = "coverage-7.15.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0a545ef5384d787d0fcac6c349afc2c5f99dcc39e13ed3c191b2c06305f64c04"},
+    {file = "coverage-7.15.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:afaa144b8f5b3bc69fe0ce50d401c46b01ab264782553bfd05a3f98804524ecb"},
+    {file = "coverage-7.15.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e1b6099490e5f88569c46b18605f556c3b30acc9a0a219cf7ef8fab8f7161ec4"},
+    {file = "coverage-7.15.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bb5f6c2cf1ffd0bf2bd925c7cdcae9b4f208e9696d453ed51eb1f5fa0cc5b45b"},
+    {file = "coverage-7.15.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:81572011fc1fc271317da35da593944daef7bfd507085e35751abbe702b74f69"},
+    {file = "coverage-7.15.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8f765d13c08497687d0780cca66115c6aa4ba6703ad43b61e94fab9db689e3a3"},
+    {file = "coverage-7.15.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:771caba880fee96493d18dfc465c318e08ab74e3bc2a3e4089e52514be6a6e54"},
+    {file = "coverage-7.15.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:433a73200848e80f27712fc113b6ff5311f29b479a7d3bd4b1106138a77f9674"},
+    {file = "coverage-7.15.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5d6fa45079db9fbeba0a69e3d91189f05301d6ac918162a53179d32fc9ed4910"},
+    {file = "coverage-7.15.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:00b6703c6640075cdce5124e9335dfdf9167272475301828acfdd09c0e5ee731"},
+    {file = "coverage-7.15.1-cp310-cp310-win32.whl", hash = "sha256:3ad9a0eac4728327fd870d52f74d2e631d176c5f178eaea2d9983ab5b9755a55"},
+    {file = "coverage-7.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:eb5fa75dc3d30e3a1b75da97973479b20ffa9b0641ff56d6e94b5f3e210daa54"},
+    {file = "coverage-7.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6506330b4a8dcf53b95bd84d8d0e817107cdb3fc1438e835029cdf0bc6612eb0"},
+    {file = "coverage-7.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8a51a8ec382c39d939cba0ab07ae949077ae4e842343bd4eed22d432358cea9"},
+    {file = "coverage-7.15.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:18ea20e3922d7f8ca9e0ef1084408d08c4ad62d5e531cb9c1f6896a99297ebea"},
+    {file = "coverage-7.15.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:aab9902a64b8390e3b56e539fddae1d79a267807fe5cb0c18d7d2f544ce867e2"},
+    {file = "coverage-7.15.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cc316264317b07a9e90d7f2b4188a15e36e9b54e651081b791b0515fa612a29"},
+    {file = "coverage-7.15.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d4e47e7eea81a8ccf060a07627654151d929da62c7b715738387c200905cec89"},
+    {file = "coverage-7.15.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c6829d9a3b55ad2b73ef5fda8302e5be03683789e88b1a079dcf4a773229c21d"},
+    {file = "coverage-7.15.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:764e045811f9c8cda436641f3f088283351d331a519b5807f19041cd0a68da1c"},
+    {file = "coverage-7.15.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:09b3b088aa24489c4082bcc35fcc8224281ab94a653dfb6d3f0c8165b0d628ab"},
+    {file = "coverage-7.15.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7911b02f57053adf8164ae63edb1c26574d24dfccabadc5268cf69310a69a358"},
+    {file = "coverage-7.15.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:664e279ed40599b8ed16f4db18d92a7e212c73129672bec8f5d96d4da48d2404"},
+    {file = "coverage-7.15.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:34fe7cf79d5f1f87f2e8ce7dc1c32950841f50e10d0120f263856acfad66de34"},
+    {file = "coverage-7.15.1-cp311-cp311-win32.whl", hash = "sha256:5e2d2536d2f57a354aa382ed303ac0e2e5c9522a508c05b998d26181b94163a7"},
+    {file = "coverage-7.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:c337da8fca7ea93ab43f3868cfcde6cf6dad32c3906b273cfbad5d7390bc423b"},
+    {file = "coverage-7.15.1-cp311-cp311-win_arm64.whl", hash = "sha256:db3403fdb7a94d5eb73e099befad8104d2a7d110a0f0d99df0de61c5d1fa756c"},
+    {file = "coverage-7.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d9476292594309db922cc841dd13b303b3c388f4c25d279884f7e2341c681f80"},
+    {file = "coverage-7.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c579056b0de461b3a62318b63d0b6ce90aed7f8158d3f00da094df82f29d189"},
+    {file = "coverage-7.15.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:23214bdbe226f2b0e9c66a7d6a1d59d4a88045dcf86e702cf0fe0d0935e3d615"},
+    {file = "coverage-7.15.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:df164be93b46b4825cc39339440a05edc54c4d1d865ba4a60fd43d151a2a1cd3"},
+    {file = "coverage-7.15.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a524fca1a6f08927d9dc2d4c873cfb7bd7202c247f08b14bdc02424071b8b304"},
+    {file = "coverage-7.15.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d70f3542cd38de85a9e257dcb1ac4c1ab4b6d7d2c2a645809207556628755d1c"},
+    {file = "coverage-7.15.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d78aa537237212c4313aabe5e964b66acc86350ed19ebc56a3e202df33b6077b"},
+    {file = "coverage-7.15.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a318112bb4f79d9d04766196d5a3388caa825908a6a9b052aa87de3d9aea7c61"},
+    {file = "coverage-7.15.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e55d24cada901963eed5bc89fa562aa033f0d84b9d3de4ecf363737c13aed11e"},
+    {file = "coverage-7.15.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3c78f0cea7275342cf2adc2ad5fdd0aafa106ad91e66d573568f2fcf62c41df5"},
+    {file = "coverage-7.15.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:86bd37eabe39977216f630a7fc1b698e7f5e81a191c7186013245c6c3d313f9d"},
+    {file = "coverage-7.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6db15c217693bdc3ca0b84de1ba9afafe1c14c26a8a29d77f4ed0de2b6132e2"},
+    {file = "coverage-7.15.1-cp312-cp312-win32.whl", hash = "sha256:359f3fbe09a51500c51966596ee4ee4070b356552c70b3b2420eb200d68e0f76"},
+    {file = "coverage-7.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:fa75dc099c126e941a9c0baa8ebd2cbc78bd778687534fe410baf754f6d9e374"},
+    {file = "coverage-7.15.1-cp312-cp312-win_arm64.whl", hash = "sha256:26f89cf6d0634375f454fa71057945ad18edb0f1607a90fecf22c57dc3dc289a"},
+    {file = "coverage-7.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:71ac4ca1658ca99160fd58cc6967110e989c34b04627f24ed6ec9f70fb24571a"},
+    {file = "coverage-7.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:26a40cbf2b13bd94af53ee02a424cb3bb96a9edfac0d00834bd068512a62714b"},
+    {file = "coverage-7.15.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4c5a5eff4ad4f9f7088fd3fc7a66d98d06566ee294b3b053309fb0a3b45be1e"},
+    {file = "coverage-7.15.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:962aa56c1c9b016d681265880eb6acc9966029d2c4c559319cc43a1abbb9b59a"},
+    {file = "coverage-7.15.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1678eb2dc57a8ce67601b029582ef6d41e9e6ca22692aaeccd4107e40f27386c"},
+    {file = "coverage-7.15.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1174900a43f6f8c425fee10d7dbddc308adefcdc78aaced32357f5ab750a0e90"},
+    {file = "coverage-7.15.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:98847557a6859cadf693792ce89f440cb89692993f60dc6d3a7e35f3d340216f"},
+    {file = "coverage-7.15.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8697b2edb57143546a24389efc11e1b000cd5800fc20d84f04edb601e4a7cfb8"},
+    {file = "coverage-7.15.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6827ac0519be3fe91bf96b4060eb00d1d24f82649b29862cd75a3cfca248b02a"},
+    {file = "coverage-7.15.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2de8ecbbc77c7e4d22572779920ed8979c69168675e96be3a548c996568c6c31"},
+    {file = "coverage-7.15.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2b25f0f0fa5260df9d7bb55d47c8bdc23fa3382c1a18f7c9cae122e6c320b1ad"},
+    {file = "coverage-7.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a2effcbd93ae340a58db718fe4181d967f84d352c4cefeaab4ff82ce813901a"},
+    {file = "coverage-7.15.1-cp313-cp313-win32.whl", hash = "sha256:895e65c96aef0cecea250f6e35e9a32f11375514e1a0cb5210e0fda128c04e8e"},
+    {file = "coverage-7.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6d0a28b63a0d75f9ed5118105d1154fc3aa40a8605a30d5d87e3d043ad90fe7"},
+    {file = "coverage-7.15.1-cp313-cp313-win_arm64.whl", hash = "sha256:b4ee9818e8bae3544379ad2c09b851c4fb886aaa8860d57a1c1316ddcb16db49"},
+    {file = "coverage-7.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a886af95f59edf67d5770fd3564d53f4a8af93f25f8c1d60d27e00d7f5674ee8"},
+    {file = "coverage-7.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:985657ebd707941de90d488d1cbb5efac20bdf81f7b91eba771624ccda4d36f4"},
+    {file = "coverage-7.15.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5bbe2a06e0a5e1404d9ffbdb49b819bbd6a3bb198ebea4c8dfe7ad9f1e1c2e81"},
+    {file = "coverage-7.15.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bde0fe24083d0b7b3dbafa7a09f0796410af1afa2523f28f5f208d8340a4aaca"},
+    {file = "coverage-7.15.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f89f7453d6d46db14cf233e2cd8edcd78de2b9c49d4f1dc109590b4e5dbfbb74"},
+    {file = "coverage-7.15.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc3656c9ecc27b36bd0907455b77f83c0069ca9ad4a66dec892b76c696eb6047"},
+    {file = "coverage-7.15.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:24d8e85a2a45e44883b488c2659f51fa761dad5353fdb319b672a93facbd2ca9"},
+    {file = "coverage-7.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:68931b5fe746ed4fdaa8892989cab9e6c35781eeb3b0ab2ded893d561e1b3652"},
+    {file = "coverage-7.15.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1ce6947e2a95534ecaa5a15e73c21e550514c980d80eda204d064d789a95f6a4"},
+    {file = "coverage-7.15.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:841befdbc89b9c82435fc25b0f4f41858b6238693e45af758bec4cfc1968171c"},
+    {file = "coverage-7.15.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5d3de58b837375e7f4c0e1a088ccab5f655efb2fd7427b729df02c862a559633"},
+    {file = "coverage-7.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b1801963f9f44ae0c0f6d737bc7aeb2bbcde7d1fe7e3b43cddc1961af42d3b41"},
+    {file = "coverage-7.15.1-cp314-cp314-win32.whl", hash = "sha256:8c7953c4128ef53b6ffb5f90d87c87d4ce26731df294760bb2314eb0e069e44b"},
+    {file = "coverage-7.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:6f0bab60a582d415f0fb535ccff13ba334a47a1538f98913330a525d23bd535a"},
+    {file = "coverage-7.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:0f410ee8f0ac4ec7db71bc0b7632a8b9994e1cad2755bd1566c17e6a162caa74"},
+    {file = "coverage-7.15.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fc868bab88e049d41fcd41766810d790a8b960053be2a45e060f5ce0d31d258b"},
+    {file = "coverage-7.15.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:206d4ec6028f2773b40932d09f074539d6bcdd8f6b318d40cb04bdbd68ed0b49"},
+    {file = "coverage-7.15.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:620482ef1c9f4e61f962e159325fe77dea59d16e39d9c9470d069053b244d864"},
+    {file = "coverage-7.15.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d385fc9b054e309ad3cecdc77b586d2af0c98aeec2fdb3773544586f366e817c"},
+    {file = "coverage-7.15.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1198bca9c0dd7c188aae1f185b0c0b5fc4f0a2b6909000858c29550320bdb07"},
+    {file = "coverage-7.15.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d0297e6a070eadb49df7cddd0ab6f420b8b689dd8904c7dd815a323168fa57e"},
+    {file = "coverage-7.15.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916fcf2214f56960e409561b37fc32a160a42b6e85483d0652d7b70fa55d707e"},
+    {file = "coverage-7.15.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f837bae572c7869ffaa502e604c87e182543012831cf87aae4586ad090ac6dcf"},
+    {file = "coverage-7.15.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3ea65e3ee6c7c32349fd00559927a9e577bdd72386087eeed1c42b62dfce9b82"},
+    {file = "coverage-7.15.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:345034976f46a1c54bd17f4e43eb30bb92cb7082fcddff03250cff136cc4eb82"},
+    {file = "coverage-7.15.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4f051a64eb8f8addb4661c2b41d6eea5b7ebc68ad4b2baea8d9bc54e1956e5f7"},
+    {file = "coverage-7.15.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a7625770f7720b49bb30d194ad2f8d50fab3c5177874af3d2399676f95f9c594"},
+    {file = "coverage-7.15.1-cp314-cp314t-win32.whl", hash = "sha256:81e503d130a472ad1bd38199ecd35116b40d92bcd31e27a2cacde035381f2070"},
+    {file = "coverage-7.15.1-cp314-cp314t-win_amd64.whl", hash = "sha256:724e878b213b302ad46e9f2fc872d386613f20ebfc492a211482d917ea76c14f"},
+    {file = "coverage-7.15.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ce2f05c14d077f406fefc4fa5e4f093ad0e0787549f6582535d6e28766f0361b"},
+    {file = "coverage-7.15.1-py3-none-any.whl", hash = "sha256:717d01e6e00bed56ad13306f19e0dd2f4f645ee8159d2c72c72301d6cfc7090c"},
+    {file = "coverage-7.15.1.tar.gz", hash = "sha256:165e9949eaf222ef1f018635d0d7f368a23bfe0212af558534c40d8c04686d67"},
 ]
 
 [package.extras]
@@ -1035,14 +987,14 @@ files = [
 
 [[package]]
 name = "docutils"
-version = "0.21.2"
+version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
 optional = false
-python-versions = ">=3.9"
-groups = ["build-test", "docs"]
+python-versions = ">=3.7"
+groups = ["build-test", "docs", "test"]
 files = [
-    {file = "docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2"},
-    {file = "docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"},
+    {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
+    {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
 ]
 
 [[package]]
@@ -1173,70 +1125,70 @@ testing = ["mock", "pytest", "pytest-cov", "watchdog"]
 
 [[package]]
 name = "hypothesis"
-version = "6.156.5"
+version = "6.156.6"
 description = "The property-based testing library for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["test"]
 files = [
-    {file = "hypothesis-6.156.5-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:aec9566fcf6f062c0730ca864491e888b5a3fd2a6e5652312d41ec700ddd1c13"},
-    {file = "hypothesis-6.156.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:cda44f5da66670907004b21927bcf5d54073f2e502775f42921251ff03e5db4f"},
-    {file = "hypothesis-6.156.5-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04fc5fb72398f32789c571c542bdcd5ef532dc584b75e24d72cdb27949e64c3a"},
-    {file = "hypothesis-6.156.5-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a70e62f189a8cc05cbdd9a30e093a6b6ca27a805cff567c0cee834a5982200e9"},
-    {file = "hypothesis-6.156.5-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:910dfa8f5b1adc259a4dd73cb06666f632bad2938fb3516d363041d6a14a1b7b"},
-    {file = "hypothesis-6.156.5-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:78bd5d844ebc49c950596ee50e7afca0da64419b85c382699469a55b65024f6b"},
-    {file = "hypothesis-6.156.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fafe8e4e62aeb73c1be0f71ccd1b387e701ccbedbde474702da8e4bce01a54e6"},
-    {file = "hypothesis-6.156.5-cp310-abi3-win32.whl", hash = "sha256:4552dbf25653e3dbdd8dc594a77732c0370ea8ba52c2df64f48a338e63107118"},
-    {file = "hypothesis-6.156.5-cp310-abi3-win_amd64.whl", hash = "sha256:cf647a0d054711e42004004b37376885a50e1b76e5f02c781a3ce674c1e13d5a"},
-    {file = "hypothesis-6.156.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:b681b79736cedfa27f7592ed0cea78c217603d3dfe2feba05d61df1f5e468da8"},
-    {file = "hypothesis-6.156.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cb3ecb0cbf7ed4f139049a123e15a043783ff659e55d7036770b975b794afac7"},
-    {file = "hypothesis-6.156.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed1f15a9c308c87758b4a7a1d062565424da63e1f02f1c60dc56f3ed2b1deeaf"},
-    {file = "hypothesis-6.156.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e2f40f5dabe72c3c5929d77588679ee2a0ee076e9ad3059ef52ae17be6f848a"},
-    {file = "hypothesis-6.156.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:de9fe227fda3c4de32d76085be8a021af3bb815aa95f9ab54b6df16d8a56fe23"},
-    {file = "hypothesis-6.156.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c3e90eb498f1c5954a1768dc34c1f10a0808b37f7e6e3a99ae336ebe2e4798ba"},
-    {file = "hypothesis-6.156.5-cp310-cp310-win_amd64.whl", hash = "sha256:96dc14d844e316c7607d330628bf68e220a601cf9a36c4eb6f57322731b26284"},
-    {file = "hypothesis-6.156.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:9c7de49e0567fb956f38c2d469b766365994bf2b23df652df6610cb6ca7bcaca"},
-    {file = "hypothesis-6.156.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81207bba26a7e616474acf4ba1e69d53fbe0aa44db7915f02ccd5112da0c5578"},
-    {file = "hypothesis-6.156.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03f1919fa139c86fad6efcb8be3b6614e5309b67f197216d21b59337e2fd04b"},
-    {file = "hypothesis-6.156.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d5fbbccaeae692f3cd9c32fd946fed49881385c16d46072b445d2d01b33858c"},
-    {file = "hypothesis-6.156.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5cee554b4d0c876215a6bd3bb68d676df9b3666b642a5b952c5c6d777dca6b1a"},
-    {file = "hypothesis-6.156.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:949c9e0fdf0632ab9ac119b99a3b6e610434b5185e86ededa4df0f83f3df4263"},
-    {file = "hypothesis-6.156.5-cp311-cp311-win_amd64.whl", hash = "sha256:717f167a5fd61097fcf1d31eab2889292f464398b3b1e306c99be2dc91de47ca"},
-    {file = "hypothesis-6.156.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0622846641949d0f1a925f458768be223b55a8f060b059734f637f3a00869a43"},
-    {file = "hypothesis-6.156.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:94f6a94269483a7a53335fa5df2ae2f7c95f76e6a953f511fff03859c2fe616f"},
-    {file = "hypothesis-6.156.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e226328d39d991d6ec73dc44e717dfa8ec0ed86cb3870995e6ae76b5fec5c157"},
-    {file = "hypothesis-6.156.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:750003b04031c9012a0571c14e97ef70111ed42bfbcefab91ba4b619474e32dd"},
-    {file = "hypothesis-6.156.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:012358f9d31fc5b0fadd092fa285d91690a1c6622e75f7120aaec4fd1b12926f"},
-    {file = "hypothesis-6.156.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:29318faf72ce169b03e90a9e1a8167b2bddb667a653ef66a2f90427b13a191ea"},
-    {file = "hypothesis-6.156.5-cp312-cp312-win_amd64.whl", hash = "sha256:3d3a71d67f5309f110855083644b8a0f032adda1c2672b08104470c05a6aac5e"},
-    {file = "hypothesis-6.156.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6bc493e3bcb815d1dfe29e0c169f1032c42eea9fd34c7cef734e744d93a17476"},
-    {file = "hypothesis-6.156.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5332cbc4bbbc1b4495f534df8c8a7b4fc50ca6a08650b1250896a36c091b0cb2"},
-    {file = "hypothesis-6.156.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8aa21d73ce8238f438eca30e09ab3b7efef37c60c4da21415903d0e45fbffd5"},
-    {file = "hypothesis-6.156.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7123442269105b66924ebcabca92705415db1dd968404f730afd93552840982"},
-    {file = "hypothesis-6.156.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8d93f58fa5b77647e5e3b620e2a6d43682adc64a51d4ce7790f0d9ef4c9a9606"},
-    {file = "hypothesis-6.156.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6b39871997ceefceb4a719eb374a3007aa2768847fa250d987acb2384be8ff5c"},
-    {file = "hypothesis-6.156.5-cp313-cp313-win_amd64.whl", hash = "sha256:a724336107450452e8fa649a3c8f24e2dc01bb7a1f12c475a9f4545f2dc0889c"},
-    {file = "hypothesis-6.156.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:0f3eccde4d2de4d0d8343076da8ee694e6fc8a9970e00c751328cc841a90500b"},
-    {file = "hypothesis-6.156.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c79afa29ef2ef0e96f147ef408ef0d8bbf7a19f218b373913422ac746494ad8e"},
-    {file = "hypothesis-6.156.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8ac71d1b07b692d7e1930d62e1232754f8e7f6507e404f4bcbe16e28a108a47"},
-    {file = "hypothesis-6.156.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff748c5746af6b83b0e5ad35eff0b99e75d021bce57556813062a34e757be48f"},
-    {file = "hypothesis-6.156.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f08d560ecabd4bff4a7f4b34bbc655cdc83b317578c7265e8da0d10b66e272e"},
-    {file = "hypothesis-6.156.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ab0598cd43f0e62ca8a58ffde04efd0783fa5795b099959717f9581fe8753355"},
-    {file = "hypothesis-6.156.5-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:6f797675b82b7417961dd0d634fe6592d5c7e0e564596a001ec6254a100dbc35"},
-    {file = "hypothesis-6.156.5-cp314-cp314-win_amd64.whl", hash = "sha256:39397347a8b524ea68f2a25dd4178edffe0165ba1cb93190c8ea696070e7b5e7"},
-    {file = "hypothesis-6.156.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e8f5093fcaa36e3a5a750b242c41005bf8800f144372dacdcf4c1c4f7ed54e24"},
-    {file = "hypothesis-6.156.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:676cbfb1ff9ad8fa0e10e63ef7e1aec8f1f15c44772375eea6708f988992adaf"},
-    {file = "hypothesis-6.156.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305e34195c4233707fa23abdfc6f1234b6b62d2579d395ed96a56f87e5064226"},
-    {file = "hypothesis-6.156.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ad53de9310c83bbf0c20901d41421eaf138609314d7421f72db39d39a7f0cf7"},
-    {file = "hypothesis-6.156.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5959642a2ba80156baa6e23cc64d40d27e0d160c019c0aae2d2de62a3537963b"},
-    {file = "hypothesis-6.156.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d8ea564a59f3f163f36b7c3522c6bd05c82a508acca5ac6bc5e1b3c265bb8814"},
-    {file = "hypothesis-6.156.5-cp314-cp314t-win_amd64.whl", hash = "sha256:f1aaebfa3d7c888ad905a6acc933d3093a227b97a136d27ea6d47a531f8bc110"},
-    {file = "hypothesis-6.156.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:47a23e44e900cc44f764483158095a138a1e5b4dd5abcd3e2b54ddf56bcc7ba3"},
-    {file = "hypothesis-6.156.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:268b5df24a92627daa04f241f1fc01331076158927debca953d19a1ac543f3d9"},
-    {file = "hypothesis-6.156.5-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e09354067493aa7a797aacb980a1dc6e063c53cae36d9db8a20bd030d3df435f"},
-    {file = "hypothesis-6.156.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a50062d059fe9f34baaf80aa31c4ef4f42d42fac2a39702d89546a04337a9a7"},
-    {file = "hypothesis-6.156.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:48173754d2e749649bdd7b978262ef4e597e697a66840e8e168fc0cc20e80ec6"},
-    {file = "hypothesis-6.156.5.tar.gz", hash = "sha256:b2780ef6f5bb2b9775763b1d2f978e3cbe31717303c3eb9aa2ada2531c30caac"},
+    {file = "hypothesis-6.156.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:caf6a93d011c10972da111c38ceb34ced20feaa8581e2b350c0655b022e27875"},
+    {file = "hypothesis-6.156.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:07f2bc9df1aeba80e12029c1618e2ee54abc440068c305d7075ffd6b85251843"},
+    {file = "hypothesis-6.156.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7baca17f4803ad4aa151732326f3990baf54c3127df44aa872ac5bdf8a98a9a6"},
+    {file = "hypothesis-6.156.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8083806645f84243aade727f4978185caaa0b7190af4318673999ee15fdbf424"},
+    {file = "hypothesis-6.156.6-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a922eedcd8618f9c2e17b79fa7b3f3f0b2df34e201958611cc3f0f46cca33c10"},
+    {file = "hypothesis-6.156.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5291bd33c4704d274d7c214d5c200e77f372a06644f5cbbe96dcbe53cb2fbf10"},
+    {file = "hypothesis-6.156.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55f3ec50161b4a95bae63bff2b5166e45935b493013d3be30ede279bf6192318"},
+    {file = "hypothesis-6.156.6-cp310-abi3-win32.whl", hash = "sha256:e96570ca5cdd9a5f2ff9e80a6fb2fd5420ebf33b833d7de5b09b6ebb26a3eb6c"},
+    {file = "hypothesis-6.156.6-cp310-abi3-win_amd64.whl", hash = "sha256:32710718c22fe8c5571464e898bb87d282837b02617d6ad68130abf7cb4843cb"},
+    {file = "hypothesis-6.156.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:afec0631a7a557acb50f665108b5d1d1123c21bc702d156a740db1cc33be4a7d"},
+    {file = "hypothesis-6.156.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583a658162ee7e1a82155e3f146932a3a2269030294f3c83f5cf52fcaa0562c3"},
+    {file = "hypothesis-6.156.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9600277defbfa769d8a6af264cbdff16294682c210c2d058ef39348fec16c0c"},
+    {file = "hypothesis-6.156.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7c3f067166bfc28b67f0042fc5fdcc87b3b58664da0c2f563fe544448b7ab3b"},
+    {file = "hypothesis-6.156.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f57842c1c5314839bdf4be5cff108589ff435cd7192c035dc48e6f14032915a5"},
+    {file = "hypothesis-6.156.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c4a787c3af0035846034461792f2a62f1c43af850feb970a5b53a629d64b52fb"},
+    {file = "hypothesis-6.156.6-cp310-cp310-win_amd64.whl", hash = "sha256:02accb187617ebaebb120da931f799a3cb0df7c38706f97f9d022441d4faf533"},
+    {file = "hypothesis-6.156.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5baec7943a14d106e982121dd4f74cfc5ef45e37c17f94fe49338d3d1377f38c"},
+    {file = "hypothesis-6.156.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5f519905ddeb10e23b8ba2c254541a5b1a8f146fe0551be94d972f4a77226f4"},
+    {file = "hypothesis-6.156.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c108655960b58ded3ca71b2dc5c69fb2ba7e9c723aeb6106facec3892d09087"},
+    {file = "hypothesis-6.156.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c8d37bebb6924729bc0bbf5852689df568842948abe4d93dd0ad3377adf76fa"},
+    {file = "hypothesis-6.156.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:74137bef6d502305c3648b2ed1a9bb4bc05fb1025e96b30a2c092204c40fe097"},
+    {file = "hypothesis-6.156.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5e0afdf79cceed20fcf0a9fb80d4064a9b2b53d4d4eecbac0e21208a13f5a31b"},
+    {file = "hypothesis-6.156.6-cp311-cp311-win_amd64.whl", hash = "sha256:84dc89caaf741a02f904ca7bd02b1af99650c75552868162290208aeecb70858"},
+    {file = "hypothesis-6.156.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a2a728b514fceb81e3f0464508911d5220fd74dadc3270f859427a686b60c4cf"},
+    {file = "hypothesis-6.156.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7489b9a8f9df8227edd6c7cd8b9ccfab2483bab24da6a474c175973ca2294f58"},
+    {file = "hypothesis-6.156.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42760873d6db1069d6edbaa355a61b9078a9950259efcfc72fc695741d7db7cd"},
+    {file = "hypothesis-6.156.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4e66aaa7385538a5d617174d47c198ee807f06de99e282a67c6cb724c69340d"},
+    {file = "hypothesis-6.156.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08796b674c0b31a5dd4119b2173823390055921588d13eb77324e861b00fd7f8"},
+    {file = "hypothesis-6.156.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4ca8cc26ea2d31d22cf7710e92951cfaa921f0f8aa1b6db33a5176335f583a4f"},
+    {file = "hypothesis-6.156.6-cp312-cp312-win_amd64.whl", hash = "sha256:c3363d3fb8015594636689572510bb6090602d8e8e838a5693c2d52d3b5b09d8"},
+    {file = "hypothesis-6.156.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:59a8def90d9a5a9b67e1ac529e903a2363ceb6cf873c209da6b4284c5daab671"},
+    {file = "hypothesis-6.156.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c574c3224563d730848bc5d1ef1683c4f83993400c0167899fe328f4bfcd4725"},
+    {file = "hypothesis-6.156.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01bb8270c46b3ef53b0c2d23ff613ea506d609d06f936d823ea57c58b66b05f7"},
+    {file = "hypothesis-6.156.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4ea6559c13606e13b645927f2e0906e52b5ac5d99b40d3abaaeb2e8c7ceeb75"},
+    {file = "hypothesis-6.156.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2d47054d0230f0dd9b6868fc030126c7a6c25527144272ff376cc4e9c39f7540"},
+    {file = "hypothesis-6.156.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:050c8c0815f88d47dd0875a92698d20d61639b7b721ee043a6d687c7f14ff7d8"},
+    {file = "hypothesis-6.156.6-cp313-cp313-win_amd64.whl", hash = "sha256:f0d73edab7b8a0051b3634f2d04d62b7e7282f8f274963b11188ee4957d672ef"},
+    {file = "hypothesis-6.156.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:34a70a7b8226e34d658072d8fb81d03f97f0a75ceb536329a321b94ce2232fd6"},
+    {file = "hypothesis-6.156.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f1969646beead7d8cf6a2537d2765af89d73056e2cb218e7fae92b83802250a3"},
+    {file = "hypothesis-6.156.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbc2ec7b7d905e6b6ec1635f6340bfa52aaab718101c59f052bc012a6b486cd8"},
+    {file = "hypothesis-6.156.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9367ae25dfa6dc1af37904785e43c4f8fe1c4118cafdc2f06514154fbdd90992"},
+    {file = "hypothesis-6.156.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:455f09107ec07c78f2a83cb8fc19e23879c9d51cdc831de6f9cb6ec4059cb9af"},
+    {file = "hypothesis-6.156.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c76634c45a3ceee4c4fdfed39aebd08b8b822ec8b0c556877ef82846fd777730"},
+    {file = "hypothesis-6.156.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:eb7e9f8343bc6b948937e6ec12e6879ed25a17b53ceccbd2b84adadd3d511698"},
+    {file = "hypothesis-6.156.6-cp314-cp314-win_amd64.whl", hash = "sha256:f9631cd604ae6032c3edf99160dc1b9e33873f2e52762246b24f07fb758652ae"},
+    {file = "hypothesis-6.156.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:1f81163d36d3763b09ffaef7c3a71e88174ca3e6816201fca9d1d159f448fdb5"},
+    {file = "hypothesis-6.156.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:556b905767e36147918634a64356aa05d8c956576f00aee01eb351678f193908"},
+    {file = "hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3f2604b28d16d696aaaf4954d20f907b27e54034df98e64746a20c74c319f03"},
+    {file = "hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe012ad66dbe7b8e8ddef6f6992ab1b36719ea64430c2bf1ff7135521052a15"},
+    {file = "hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5bfa3c7b758f7278081c6bfec5f89b43c4eb075c0c9eb095323f7a9eb019b513"},
+    {file = "hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d0db1f4573800c618773622f03cb6533bb3377430ef938c9476ba10c39d22591"},
+    {file = "hypothesis-6.156.6-cp314-cp314t-win_amd64.whl", hash = "sha256:38cd0c4a7b9f809f1e23a4d15adfa9c5d99869b9afc327350a5e563350b78e48"},
+    {file = "hypothesis-6.156.6-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8893b4da90e06828846c1b100c3414a7729d047a020d854c0899ae9339df0e70"},
+    {file = "hypothesis-6.156.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b7fc0b7df9b28d028e4cc295b2ac8fbbbc22e090a23382c92fff5e37696be74f"},
+    {file = "hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38ed3178526382d392d04ad699ad7a2e53845e521a09d40f1cbbc1e1ff63ba48"},
+    {file = "hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ad94e28aabf4db0d479297d43b8a2a01e7caaa9bdfccfdac7a4a3717e05b993"},
+    {file = "hypothesis-6.156.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:983a5cfd955994bffc7eb02976241f7a1f3c2d94dbc3389430c45858fa5c1ae0"},
+    {file = "hypothesis-6.156.6.tar.gz", hash = "sha256:96de02faefa3ce079873541da96f42595583bb001e8e4219294ed7d4501cc4cc"},
 ]
 
 [package.dependencies]
@@ -1644,14 +1596,14 @@ files = [
 
 [[package]]
 name = "nox"
-version = "2026.4.10"
+version = "2026.7.11"
 description = "Flexible test automation."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["test"]
 files = [
-    {file = "nox-2026.4.10-py3-none-any.whl", hash = "sha256:082c117627590d9b90aa21f86df89b310b07c5842539524203bcb3c719f116c1"},
-    {file = "nox-2026.4.10.tar.gz", hash = "sha256:2d0af5374f3f37a295428c927d1b04a8182aa01762897d172446dda2f1ce9692"},
+    {file = "nox-2026.7.11-py3-none-any.whl", hash = "sha256:f5e811693ee8374d269396204eb39990d2084da67ed968239f94301805c9a169"},
+    {file = "nox-2026.7.11.tar.gz", hash = "sha256:dec9bd2c854540a2d5c0b841eaaf1d23a7c26cd90af36d9f1f1668b34524bfd9"},
 ]
 
 [package.dependencies]
@@ -1661,7 +1613,7 @@ colorlog = ">=2.6.1,<7"
 dependency-groups = ">=1.1"
 humanize = ">=4"
 packaging = ">=22"
-virtualenv = {version = ">=20.15", markers = "python_version >= \"3.10\""}
+virtualenv = ">=20.15"
 
 [package.extras]
 pbs = ["pbs-installer[all] (>=2025.1.6)"]
@@ -2305,24 +2257,24 @@ toml = ["tomli (>=2.0.1)"]
 
 [[package]]
 name = "readme-renderer"
-version = "45.0"
+version = "43.0"
 description = "readme_renderer is a library for rendering readme descriptions for Warehouse"
 optional = false
-python-versions = ">=3.10"
+python-versions = ">=3.8"
 groups = ["build-test"]
 files = [
-    {file = "readme_renderer-45.0-py3-none-any.whl", hash = "sha256:3385ed220117104a2bceb4a9dac8c5fdf6d1f96890d7ea2a9c7174fd5c84091f"},
-    {file = "readme_renderer-45.0.tar.gz", hash = "sha256:030a8fac74904f8fba11ad1bb6964e3f76e896dc7e5e71f16af190c9056696d1"},
+    {file = "readme_renderer-43.0-py3-none-any.whl", hash = "sha256:19db308d86ecd60e5affa3b2a98f017af384678c63c88e5d4556a380e674f3f9"},
+    {file = "readme_renderer-43.0.tar.gz", hash = "sha256:1818dd28140813509eeed8d62687f7cd4f7bad90d4db586001c5dc09d4fde311"},
 ]
 
 [package.dependencies]
-comrak = {version = ">=0.0.11", optional = true, markers = "extra == \"md\""}
-docutils = ">=0.21.2"
+cmarkgfm = {version = ">=0.8.0", optional = true, markers = "extra == \"md\""}
+docutils = ">=0.13.1"
 nh3 = ">=0.2.14"
 Pygments = ">=2.5.1"
 
 [package.extras]
-md = ["comrak (>=0.0.11)"]
+md = ["cmarkgfm (>=0.8.0)"]
 
 [[package]]
 name = "referencing"
@@ -3080,14 +3032,14 @@ testing = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
 name = "virtualenv"
-version = "21.6.0"
+version = "21.6.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev", "test"]
 files = [
-    {file = "virtualenv-21.6.0-py3-none-any.whl", hash = "sha256:bce9d097950fef9d81129b333babfb7767072850c2f1acce0ec536708401bfd1"},
-    {file = "virtualenv-21.6.0.tar.gz", hash = "sha256:e18a4d750f2b64dea73e72ffde3922f3c52365fabdc8157ebd3da20d031c4734"},
+    {file = "virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b"},
+    {file = "virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128"},
 ]
 
 [package.dependencies]
@@ -3303,4 +3255,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "4549e9bf8f098ee57636585a7bbe0374c31a3590d4ae4387219045110eae1ec8"
+content-hash = "2b3a52df9fa6843f66d7cde6f9ee0db883e9f2dd8073bad0fb5b3e7cf0d7ba93"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ pytest-doctestplus = "^1.2.1"
 hypothesis = "^6.99.13"
 nox = ">=2024.4.15"
 watchdog = "^6.0.0"
-#rst-extract = {git = "https://github.com/teald/rst_extract/"}
+docutils = "^0.20.1"
 objgraph = "^3.6.2"
 
 
@@ -233,6 +233,6 @@ convention = "numpy"
 [tool.ruff.lint.flake8-pytest-style]
 mark-parentheses = false
 
-#[tool.script_tests]
-#"docs/quickstart.rst" = ""
-#"docs/manuals/usermanual/intro.rst" = ""
+[tool.script_tests]
+"docs/quickstart.rst" = ""
+"docs/manuals/usermanual/intro.rst" = ""

--- a/tests/script_tests/__init__.py
+++ b/tests/script_tests/__init__.py
@@ -7,13 +7,14 @@ class PythonCodeBlockExtractor(nodes.NodeVisitor):
     A custom NodeVisitor that extracts Python code blocks from a
     docutils document tree.
     """
+
     def __init__(self, document):
         super().__init__(document)
         self.code_blocks = []
 
     def visit_literal_block(self, node):
         # Check if the block has 'python' specified in its classes
-        if 'python' in node.get('classes', []):
+        if "python" in node.get("classes", []):
             # Extract the raw code text inside the block
             self.code_blocks.append(node.astext())
 
@@ -30,4 +31,3 @@ def extract_python_code(rst_text):
     doctree.walk(extractor)
 
     return extractor.code_blocks
-

--- a/tests/script_tests/__init__.py
+++ b/tests/script_tests/__init__.py
@@ -1,0 +1,33 @@
+from docutils.core import publish_doctree
+from docutils import nodes
+
+
+class PythonCodeBlockExtractor(nodes.NodeVisitor):
+    """
+    A custom NodeVisitor that extracts Python code blocks from a
+    docutils document tree.
+    """
+    def __init__(self, document):
+        super().__init__(document)
+        self.code_blocks = []
+
+    def visit_literal_block(self, node):
+        # Check if the block has 'python' specified in its classes
+        if 'python' in node.get('classes', []):
+            # Extract the raw code text inside the block
+            self.code_blocks.append(node.astext())
+
+    def unknown_visit(self, node):
+        pass  # Ignore other node types
+
+
+def extract_python_code(rst_text):
+    # Parse the RST text into an internal document tree
+    doctree = publish_doctree(rst_text)
+
+    # Initialize the visitor and walk the tree
+    extractor = PythonCodeBlockExtractor(doctree)
+    doctree.walk(extractor)
+
+    return extractor.code_blocks
+

--- a/tests/script_tests/__init__.py
+++ b/tests/script_tests/__init__.py
@@ -1,5 +1,5 @@
-from docutils.core import publish_doctree
 from docutils import nodes
+from docutils.core import publish_doctree
 
 
 class PythonCodeBlockExtractor(nodes.NodeVisitor):

--- a/tests/script_tests/test_pyproject_scripts.py
+++ b/tests/script_tests/test_pyproject_scripts.py
@@ -9,14 +9,13 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
+import tempfile
 
 import pytest
 
-if int(sys.version_info[0]) == 3 and int(sys.version_info[1]) >= 12:
-    from tomllib import load as toml_load
+from tomllib import load as toml_load
 
-else:
-    from tomli import load as toml_load
+from . import extract_python_code
 
 
 @functools.cache
@@ -39,45 +38,41 @@ def scripts() -> dict[str, str]:
     return scripts
 
 
-def create_rst_extract_command(script: str, options: str | list[str]) -> str:
-    """If the script is a Python script, use ``rst-extract``."""
-    python_binary = sys.executable
-    command = [
-        python_binary,
-        "-m",
-        "rst_extract",
-        str(script),
-        "--execute",
-        "--python-bin",
-        str(python_binary),
-    ]
-
-    if isinstance(options, str):
-        options = shlex.split(options)
-
-    command += options
-
-    return command
-
-
 @pytest.mark.parametrize("script, options", tuple(scripts().items()))
 def test_script_executes(
     script: str, options: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test the script."""
-    # Use temporary directory as the working directory
-    command = create_rst_extract_command(script, options)
 
+    # Read the RST file.
+    with open(script, "r") as file:
+        rst_content = file.read()
+
+    # Extract the Python code blocks from the RST content and write them
+    # to a temporary Python file.
+    extracted_code_blocks = extract_python_code(rst_content)
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as temp_file:
+        temp_file.write("\n\n".join(extracted_code_blocks))
+        temp_file_path = Path(temp_file.name)
+
+    # Use temporary directory as the working directory
     monkeypatch.chdir(tmp_path)
-    result = subprocess.run(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+
+    # Run the temporary Python file using subprocess and capture the output.
+    try:
+        result = subprocess.run(
+                ['python', temp_file_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+    finally:
+        # Clean up the temporary file
+        temp_file_path.unlink()
 
     return_code = result.returncode
     stdout = result.stdout.decode()
     stderr = result.stderr.decode()
+
+    print(f"STDERR for {script}:\n{stderr}")
 
     assert return_code == 0
     assert not stderr


### PR DESCRIPTION
The dependency on a custom, personal script has been replaced with docutils.  The function create_test_file used in the intro.rst had mysteriously disappeared; it has been added back.